### PR TITLE
Update moonshot-trust-router.tids.init

### DIFF
--- a/debian/moonshot-trust-router.tids.init
+++ b/debian/moonshot-trust-router.tids.init
@@ -41,7 +41,7 @@ LOGFILE="$TIDS_LOGDIR/tids.log"
 
 [ -f "$LOGFILE" ] || touch $LOGFILE && chown $TIDS_USER:$TIDS_GROUP $LOGFILE
 
-OPTIONS="$PIDFILE $LOGFILE $ipaddr $gssname $hostname $/var/lib/trust_router/keys"
+OPTIONS="$PIDFILE $LOGFILE $ipaddr $gssname $hostname /var/lib/trust_router/keys"
 
 case $1 in
     start)


### PR DESCRIPTION
Remove an erroneous $ sign
