### PR TITLE
[RFC] Basic syslog for trust router

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,8 @@ common_srcs = common/tr_name.c \
 	common/jansson_iterators.h \
 	common/tr_msg.c \
 	common/tr_dh.c \
-	common/tr_util.c
+	common/tr_util.c \
+        common/tr_extlog.c
 
 check_PROGRAMS = common/t_constraint
 TESTS = common/t_constraint
@@ -51,7 +52,8 @@ libtr_tid_la_LDFLAGS = $(AM_LDFLAGS) -version-info 2 -no-undefined
 pkginclude_HEADERS = include/trust_router/tid.h include/trust_router/tr_name.h \
 	include/trust_router/tr_dh.h \
 	include/trust_router/tr_constraint.h \
-	include/trust_router/tr_versioning.h 
+	include/trust_router/tr_versioning.h \
+        include/trust_router/tr_extlog.h
 
 noinst_HEADERS = include/gsscon.h include/tr_config.h \
 	include/tr_debug.h \

--- a/common/tr_extlog.c
+++ b/common/tr_extlog.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2014, JANET(UK)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JANET(UK) nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdlib.h>
+#include <syslog.h>
+#include <trust_router/tr_extlog.h>
+#include <tid_internal.h>
+
+#define EXTLOG_PREFIX "F-TICKS/abfab/1.0"
+#define EXTLOG_MAX_MESSAGE_SIZE 65536
+#define EXTLOG_FIELD_SEP "#"
+#define EXTLOG_MSG_TERMINATOR "#"
+#define EXTLOG_KV_SEP "="
+#define EXTLOG_OVERHEAD strlen(EXTLOG_PREFIX)
+
+static unsigned int tr_extlog_enabled;
+static unsigned int tr_extlog_opened = 0;
+
+static void fire_extlog(const int pri, const char *msg) {
+
+  syslog(pri, "%s%s%s", EXTLOG_PREFIX, msg, EXTLOG_MSG_TERMINATOR);
+}
+
+static char *extlog_fmt(const char *key, char *value) {
+
+  if (NULL != key) {
+
+    /* Rewrite any NULL's to "nones" */
+    char *val = NULL == value ? "none" : value;
+
+    size_t len = strlen(key)
+               + strlen(val)
+               + strlen(EXTLOG_FIELD_SEP)
+               + strlen(EXTLOG_KV_SEP)
+               + 1;
+
+    char *buf = malloc(len);
+
+    snprintf(buf, len, "%s%s%s%s", EXTLOG_FIELD_SEP, key, EXTLOG_KV_SEP, val);
+
+    return buf;
+  }
+  else {
+
+    fprintf(stderr, "extlog_fmt: Message dropped, null pointer passed.\n");
+    return NULL;
+  }
+}
+
+static void extlog_free_array(const int count, char *array[]) {
+
+   int i;
+
+   for(i = 0; i < count; i++) {
+      free(array[i]);
+   }
+}
+
+static char *extlog_join_msg(const int count, char *array[]) {
+
+  int i;
+  int len = 1; /* start at one to account for terminator */
+
+  /* evaluate length of concatenated string */
+  for(i = 0; i < count; i++) {
+
+    if ((len + strlen(array[i]) + EXTLOG_OVERHEAD) <= EXTLOG_MAX_MESSAGE_SIZE) {
+
+      len += strlen(array[i]);
+    }
+  }
+
+  int remain = len - 1;
+  char *buf = (char *) calloc(len, sizeof(char *));
+
+  /* join fields up to count */
+  for(i = 0; i < count; i++) {
+
+    if ((strlen(buf) + strlen(array[i]) + EXTLOG_OVERHEAD + 1) <= EXTLOG_MAX_MESSAGE_SIZE) {
+
+      strncat(buf, array[i], remain);
+      remain -= strlen(array[i]);
+    }
+    else {
+
+      fprintf(stderr, "extlog_join_message: Attribute dropped, too long.\n");
+    }
+  }
+
+  return buf;
+}
+
+void tr_extlog_enable() {
+
+  tr_extlog_enabled = 1;
+  return;
+}
+
+void tr_extlog_disable() {
+
+  tr_extlog_close();
+  tr_extlog_enabled = 0;
+  return;
+}
+
+int tr_extlog_open() {
+
+  if (tr_extlog_enabled && !tr_extlog_opened) {
+
+    openlog(NULL, LOG_PID | LOG_NDELAY, LOG_AUTHPRIV);
+    tr_extlog_opened = 1;
+  }
+
+  return tr_extlog_opened;
+}
+
+void tr_extlog_close() {
+
+  if (tr_extlog_enabled) {
+
+    closelog();
+    tr_extlog_opened = 0;
+  }
+}
+
+void tr_extlog_resp(TID_RESP *resp) {
+
+  if (tr_extlog_enabled && tr_extlog_open()) {
+    if (NULL != resp) {
+
+      char *attrs[] = { extlog_fmt("result", resp->result ? "error" : "success"),
+                        extlog_fmt("comm", NULL != resp->comm ? resp->comm->buf : NULL),
+                        extlog_fmt("rp_realm", NULL != resp->rp_realm ? resp->rp_realm->buf : NULL),
+                        extlog_fmt("realm", NULL != resp->realm ? resp->realm->buf : NULL),
+                        extlog_fmt("err", NULL != resp->err_msg ? resp->err_msg->buf : NULL)
+                      };
+
+      char *msg = extlog_join_msg(sizeof(attrs) / sizeof(attrs[0]), attrs);
+      extlog_free_array(sizeof(attrs) / sizeof(attrs[0]), attrs);
+
+      fire_extlog(LOG_NOTICE, msg);
+
+      free(msg);
+    }
+    else {
+
+      fprintf(stderr, "tr_extlog_resp: Message dropped, null pointer passed.\n");
+    }
+  }
+}
+
+void tr_extlog_req(TID_REQ *req) {
+
+  if (tr_extlog_enabled && tr_extlog_open()) {
+    if (NULL != req) {
+
+      char *attrs[] = { extlog_fmt("comm", NULL != req->comm ? req->comm->buf : NULL),
+                        extlog_fmt("rp_realm", NULL != req->rp_realm ? req->rp_realm->buf : NULL),
+                        extlog_fmt("realm", NULL != req->realm ? req->realm->buf : NULL),
+                      };
+
+      char *msg = extlog_join_msg(sizeof(attrs) / sizeof(attrs[0]), attrs);
+      extlog_free_array(sizeof(attrs) / sizeof(attrs[0]), attrs);
+
+      fire_extlog(LOG_NOTICE, msg);
+
+      free(msg);
+    }
+    else {
+
+          fprintf(stderr, "tr_extlog_req: Message dropped, null pointer passed.\n");
+    }
+  }
+}
+
+void tr_extlog_simple(const char *fmt, ...) {
+
+  if (tr_extlog_enabled && tr_extlog_open()) {
+    if (NULL != fmt) {
+
+      char *buf = malloc(EXTLOG_MAX_MESSAGE_SIZE);
+
+      va_list ap;
+      va_start(ap, fmt);
+
+      vsnprintf(buf, EXTLOG_MAX_MESSAGE_SIZE, fmt, ap);
+
+      char *msg = extlog_fmt("msg", buf);
+
+      fire_extlog(LOG_NOTICE, msg);
+
+      free(msg);
+      free(buf);
+    }
+    else {
+
+          fprintf(stderr, "tr_extlog_simple: Message dropped, null pointer passed.\n");
+    }
+  }
+}

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,6 @@ AC_CHECK_LIB([sqlite3], [sqlite3_open],,
     [AC_MSG_ERROR([Please install sqlite3 development])])
 AC_CHECK_LIB([jansson], [json_object])
 AC_CHECK_LIB([crypto], [DH_new])
-AC_CHECK_HEADERS(gssapi.h gssapi_ext.h jansson.h talloc.h openssl/dh.h openssl/bn.h)
+AC_CHECK_HEADERS(gssapi.h gssapi_ext.h jansson.h talloc.h openssl/dh.h openssl/bn.h syslog.h)
 AC_CONFIG_FILES([Makefile gsscon/Makefile])
 AC_OUTPUT

--- a/include/tr_config.h
+++ b/include/tr_config.h
@@ -47,6 +47,7 @@
 #define TR_DEFAULT_MAX_TREE_DEPTH 12
 #define TR_DEFAULT_TR_PORT 12308
 #define TR_DEFAULT_TIDS_PORT 12309
+#define TR_DEFAULT_EXTLOG 0
 
 typedef enum tr_cfg_rc {
   TR_CFG_SUCCESS = 0,	/* No error */
@@ -60,6 +61,7 @@ typedef struct tr_cfg_internal {
   unsigned int max_tree_depth;
   unsigned int tids_port;
   const char *hostname;
+  unsigned int extlog;
 } TR_CFG_INTERNAL;
 
 typedef struct tr_cfg {

--- a/include/trust_router/tr_extlog.h
+++ b/include/trust_router/tr_extlog.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014, JANET(UK)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JANET(UK) nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef TR_EXTLOG_H
+#define TR_EXTLOG_H
+
+#include <trust_router/tr_versioning.h>
+#include <tid_internal.h>
+
+TR_EXPORT void tr_extlog_enable(void);
+TR_EXPORT void tr_extlog_disable(void);
+TR_EXPORT int tr_extlog_open(void);
+TR_EXPORT void tr_extlog_close(void);
+TR_EXPORT void tr_extlog_resp(TID_RESP *resp);
+TR_EXPORT void tr_extlog_req(TID_REQ *req);
+TR_EXPORT void tr_extlog_simple(const char *fmt, ...);
+
+#endif

--- a/redhat/default-main.cfg
+++ b/redhat/default-main.cfg
@@ -1,5 +1,6 @@
 {"tr_internal":{"max_tree_depth": 4,
                 "hostname":"tr.moonshot.local",
-		"tids_port" : 12309
+		"tids_port" : 12309,
+		"extlog" : false
                }
 }

--- a/tid/tids.c
+++ b/tid/tids.c
@@ -45,6 +45,7 @@
 #include <talloc.h>
 #include <tid_internal.h>
 #include <gsscon.h>
+#include <trust_router/tr_extlog.h>
 #include <tr_msg.h>
 
 static TID_RESP *tids_create_response (TIDS_INSTANCE *tids, TID_REQ *req) 
@@ -266,15 +267,27 @@ int tids_send_response (TIDS_INSTANCE *tids, TID_REQ *req, TID_RESP *resp)
   
   if (NULL == (resp_buf = tr_msg_encode(&mresp))) {
     fprintf(stderr, "tids_send_response: Error encoding json response.\n");
+
+    tr_extlog_req(req);
+    tr_extlog_simple("tids_send_response: Error encoding json response.");
+
     return -1;
   }
 
   fprintf(stderr, "tids_send_response: Encoded response:\n%s\n", resp_buf);
   
+  /* If external logging is enabled, fire off a message */
+  /* TODO Can be moved to end once segfault in gsscon_write_encrypted_token fixed */
+  tr_extlog_resp(resp);
+
   /* Send the response over the connection */
   if (err = gsscon_write_encrypted_token (req->conn, req->gssctx, resp_buf, 
 					  strlen(resp_buf) + 1)) {
     fprintf(stderr, "tids_send_response: Error sending response over connection.\n");
+
+    tr_extlog_req(req);
+    tr_extlog_simple("tids_send_response: Error sending response over connection.");
+
     return -1;
   }
 
@@ -368,6 +381,8 @@ int tids_start (TIDS_INSTANCE *tids,
   tids->hostname = hostname;
   tids->cookie = cookie;
 
+  tr_extlog_simple("Trust Path Query Server starting on host %s:%d.", hostname, port);
+
   while(1) {	/* accept incoming conns until we are stopped */
 
     if (0 > (conn = accept(listen, NULL, NULL))) {
@@ -398,6 +413,9 @@ int tids_start (TIDS_INSTANCE *tids,
 
 void tids_destroy (TIDS_INSTANCE *tids)
 {
+  /* close syslog connection if syslog is enabled */
+  tr_extlog_close();
+
   if (tids)
     free(tids);
 }

--- a/tr/tr_main.c
+++ b/tr/tr_main.c
@@ -42,6 +42,7 @@
 #include <tr_comm.h>
 #include <tr_idp.h>
 #include <tr_rp.h>
+#include <trust_router/tr_extlog.h>
 
 /* Structure to hold TR instance and original request in one cookie */
 typedef struct tr_resp_cookie {
@@ -282,6 +283,7 @@ int main (int argc, const char *argv[])
 
   /* start the trust path query server, won't return unless fatal error. */
   if (0 != (err = tids_start(tr->tids, &tr_tids_req_handler, &tr_tids_gss_handler, tr->active_cfg->internal->hostname, tr->active_cfg->internal->tids_port, (void *)tr))) {
+    tr_extlog_simple("Trust Path Query Server failed on host %s:%d.", tr->active_cfg->internal->hostname, tr->active_cfg->internal->tids_port);
     fprintf (stderr, "Error from Trust Path Query Server, err = %d.\n", err);
     exit(err);
   }

--- a/trust_router.spec
+++ b/trust_router.spec
@@ -1,7 +1,7 @@
 %global optflags %{optflags} -Wno-parentheses
 Name:           trust_router
-Version:        1.4.1
-Release:        3%{?dist}
+Version:        1.4.2
+Release:        1%{?dist}
 Summary:        Moonshot Trust Router
 
 Group:          System Environment/Libraries


### PR DESCRIPTION
These changes log the result of trust path requests transiting the trust router and certain kinds of failure into syslog.

This will allow any log aggregator that supports syslog as a transport (namely graylog2, but pretty much every log management tool supports syslog).

Making this work in trust_router has the side effect of also making it work in the standalone TIDS, however this is currently not enabled because the only configuration mechanism TIDS has for configuration is the ever-growing command line.

Comments appreciated.