### PR TITLE
Logging changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ common_srcs = common/tr_name.c \
 	common/jansson_iterators.h \
 	common/tr_msg.c \
 	common/tr_dh.c \
+        common/tr_debug.c \
 	common/tr_util.c
 
 check_PROGRAMS = common/t_constraint
@@ -39,6 +40,7 @@ tid_example_tids_SOURCES = tid/example/tids_main.c
 tid_example_tids_LDADD = gsscon/libgsscon.la libtr_tid.la
 
 common_dh_test_tr_dh_test_SOURCES = common/tr_dh.c \
+common/tr_debug.c \
 common/dh_test/dh_test.c
 
 libtr_tid_la_SOURCES = tid/tids.c tid/tidc.c tid/tid_req.c tid/tid_resp.c \
@@ -49,12 +51,12 @@ libtr_tid_la_LIBADD = gsscon/libgsscon.la
 libtr_tid_la_LDFLAGS = $(AM_LDFLAGS) -version-info 2 -no-undefined
 
 pkginclude_HEADERS = include/trust_router/tid.h include/trust_router/tr_name.h \
+	include/tr_debug.h \
 	include/trust_router/tr_dh.h \
 	include/trust_router/tr_constraint.h \
 	include/trust_router/tr_versioning.h 
 
 noinst_HEADERS = include/gsscon.h include/tr_config.h \
-	include/tr_debug.h \
 	include/tr_msg.h include/tr.h \
 	include/tr_idp.h include/tr_rp.h \
 	include/tr_comm.h include/tr_apc.h \

--- a/common/tr_comm.c
+++ b/common/tr_comm.c
@@ -37,6 +37,7 @@
 #include <tr.h>
 #include <tr_comm.h>
 #include <tr_rp.h>
+#include <tr_debug.h>
 
 TR_IDP_REALM *tr_find_comm_idp (TR_COMM *comm, TR_NAME *idp_realm)
 {
@@ -48,7 +49,7 @@ TR_IDP_REALM *tr_find_comm_idp (TR_COMM *comm, TR_NAME *idp_realm)
 
   for (idp = comm->idp_realms; NULL != idp; idp = idp->next) {
     if (!tr_name_cmp (idp_realm, idp->realm_id)) {
-      fprintf(stderr, "tr_find_comm_idp: Found %s.\n", idp_realm->buf);
+      tr_debug("tr_find_comm_idp: Found %s.", idp_realm->buf);
       return idp;
     }
   }
@@ -66,7 +67,7 @@ TR_RP_REALM *tr_find_comm_rp (TR_COMM *comm, TR_NAME *rp_realm)
 
   for (rp = comm->rp_realms; NULL != rp; rp = rp->next) {
     if (!tr_name_cmp (rp_realm, rp->realm_name)) {
-      fprintf(stderr, "tr_find_comm_idp: Found %s.\n", rp_realm->buf);
+      tr_debug("tr_find_comm_idp: Found %s.", rp_realm->buf);
       return rp;
     }
   }

--- a/common/tr_config.c
+++ b/common/tr_config.c
@@ -39,12 +39,13 @@
 #include <talloc.h>
 
 #include <tr_config.h>
+#include <tr_debug.h>
 #include <tr.h>
 #include <tr_filter.h>
 #include <trust_router/tr_constraint.h>
 
 void tr_print_config (FILE *stream, TR_CFG *cfg) {
-  fprintf(stream, "tr_print_config: Not yet implemented.\n");
+  fprintf(stream, "tr_print_config: Not yet implemented.");
   return;
 }
 
@@ -61,6 +62,10 @@ TR_CFG_RC tr_apply_new_config (TR_INSTANCE *tr) {
     tr_cfg_free(tr->active_cfg);
 
   tr->active_cfg = tr->new_cfg;
+
+  tr_log_threshold(tr->active_cfg->internal->log_threshold);
+  tr_console_threshold(tr->active_cfg->internal->console_threshold);
+
   return TR_CFG_SUCCESS;
 }
 
@@ -69,6 +74,9 @@ static TR_CFG_RC tr_cfg_parse_internal (TR_CFG *trc, json_t *jcfg) {
   json_t *jmtd = NULL;
   json_t *jtp = NULL;
   json_t *jhname = NULL;
+  json_t *jlog = NULL;
+  json_t *jconthres = NULL;
+  json_t *jlogthres = NULL;
 
   if ((!trc) || (!jcfg))
     return TR_CFG_BAD_PARAMS;
@@ -85,7 +93,7 @@ static TR_CFG_RC tr_cfg_parse_internal (TR_CFG *trc, json_t *jcfg) {
       if (json_is_number(jmtd)) {
 	trc->internal->max_tree_depth = json_integer_value(jmtd);
       } else {
-	fprintf(stderr,"tr_cfg_parse_internal: Parsing error, max_tree_depth is not a number.\n");
+	tr_debug("tr_cfg_parse_internal: Parsing error, max_tree_depth is not a number.");
 	return TR_CFG_NOPARSE;
       }
     } else {
@@ -96,7 +104,7 @@ static TR_CFG_RC tr_cfg_parse_internal (TR_CFG *trc, json_t *jcfg) {
       if (json_is_number(jtp)) {
 	trc->internal->tids_port = json_integer_value(jtp);
       } else {
-	fprintf(stderr,"tr_cfg_parse_internal: Parsing error, port is not a number.\n");
+	tr_debug("tr_cfg_parse_internal: Parsing error, port is not a number.");
 	return TR_CFG_NOPARSE;
       }
     } else {
@@ -107,11 +115,42 @@ static TR_CFG_RC tr_cfg_parse_internal (TR_CFG *trc, json_t *jcfg) {
       if (json_is_string(jhname)) {
 	trc->internal->hostname = json_string_value(jhname);
       } else {
-	fprintf(stderr,"tr_cfg_parse_internal: Parsing error, hostname is not a string.\n");
+	tr_debug("tr_cfg_parse_internal: Parsing error, hostname is not a string.");
 	return TR_CFG_NOPARSE;
       }
     }
-    fprintf(stderr, "tr_cfg_parse_internal: Internal config parsed.\n");
+
+    if (NULL != (jlog = json_object_get(jcfg, "logging"))) {
+      if (NULL != (jlogthres = json_object_get(jint, "log_threshold"))) {
+        if (json_is_string(jlogthres)) {
+       	  trc->internal->log_threshold = str2sev(json_string_value(jlogthres));
+        } else {
+          tr_debug("tr_cfg_parse_internal: Parsing error, log_threshold is not a string.");
+          return TR_CFG_NOPARSE;
+        }
+      } else {
+        /* If not configured, use the default */
+        trc->internal->log_threshold = TR_DEFAULT_LOG_THRESHOLD;
+      }
+
+      if (NULL != (jconthres = json_object_get(jint, "console_threshold"))) {
+        if (json_is_string(jconthres)) {
+            trc->internal->console_threshold = str2sev(json_string_value(jconthres));
+        } else {
+          tr_debug("tr_cfg_parse_internal: Parsing error, console_threshold is not a string.");
+          return TR_CFG_NOPARSE;
+        }
+      } else {
+        /* If not configured, use the default */
+        trc->internal->console_threshold = TR_DEFAULT_CONSOLE_THRESHOLD;
+      }
+    } else {
+        /* If not configured, use the default */
+        trc->internal->console_threshold = TR_DEFAULT_CONSOLE_THRESHOLD;
+        trc->internal->log_threshold = TR_DEFAULT_LOG_THRESHOLD;
+    }
+
+    tr_debug("tr_cfg_parse_internal: Internal config parsed.");
     return TR_CFG_SUCCESS;
   }
   return TR_CFG_SUCCESS;
@@ -127,13 +166,13 @@ static TR_CONSTRAINT *tr_cfg_parse_one_constraint (TR_CFG *trc, char *ctype, jso
       (0 >= json_array_size(jc)) ||
       (TR_MAX_CONST_MATCHES < json_array_size(jc)) ||
       (!json_is_string(json_array_get(jc, 0)))) {
-    fprintf(stderr, "tr_cfg_parse_one_constraint: config error.\n");
+    tr_debug("tr_cfg_parse_one_constraint: config error.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   if (NULL == (cons = talloc(trc, TR_CONSTRAINT))) {
-    fprintf(stderr, "tr_cfg_parse_one_constraint: Out of memory (cons).\n");
+    tr_debug("tr_cfg_parse_one_constraint: Out of memory (cons).");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -141,7 +180,7 @@ static TR_CONSTRAINT *tr_cfg_parse_one_constraint (TR_CFG *trc, char *ctype, jso
   memset(cons, 0, sizeof(TR_CONSTRAINT));
 
   if (NULL == (cons->type = tr_new_name(ctype))) {
-    fprintf(stderr, "tr_cfg_parse_one_constraint: Out of memory (type).\n");
+    tr_debug("tr_cfg_parse_one_constraint: Out of memory (type).");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -168,26 +207,26 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
 
   if ((NULL == (jftype = json_object_get(jfilt, "type"))) ||
       (!json_is_string(jftype))) {
-    fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing filter type.\n");
+    tr_debug("tr_cfg_parse_one_filter: Error parsing filter type.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   if ((NULL == (jfls = json_object_get(jfilt, "filter_lines"))) ||
       (!json_is_array(jfls))) {
-    fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing filter type.\n");
+    tr_debug("tr_cfg_parse_one_filter: Error parsing filter type.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   if (TR_MAX_FILTER_LINES < json_array_size(jfls)) {
-    fprintf(stderr, "tr_cfg_parse_one_filter: Filter has too many filter_lines, maximimum of %d.\n", TR_MAX_FILTER_LINES);
+    tr_debug("tr_cfg_parse_one_filter: Filter has too many filter_lines, maximimum of %d.", TR_MAX_FILTER_LINES);
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   if (NULL == (filt = talloc(trc, TR_FILTER))) {
-    fprintf(stderr, "tr_cfg_parse_one_filter: Out of memory.\n");
+    tr_debug("tr_cfg_parse_one_filter: Out of memory.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -198,7 +237,7 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
     filt->type = TR_FILTER_TYPE_RP_PERMITTED;
   }
   else {
-    fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing filter type, unknown type '%s'.\n", json_string_value(jftype));
+    tr_debug("tr_cfg_parse_one_filter: Error parsing filter type, unknown type '%s'.", json_string_value(jftype));
     *rc = TR_CFG_NOPARSE;
     tr_filter_free(filt);
     return NULL;
@@ -209,7 +248,7 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
 
     if ((NULL == (jfaction = json_object_get(json_array_get(jfls, i), "action"))) ||
 	(!json_is_string(jfaction))) {
-      fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing filter action.\n");
+      tr_debug("tr_cfg_parse_one_filter: Error parsing filter action.");
       *rc = TR_CFG_NOPARSE;
       tr_filter_free(filt);
       return NULL;
@@ -218,21 +257,21 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
     if ((NULL == (jfspecs = json_object_get(json_array_get(jfls, i), "filter_specs"))) ||
 	(!json_is_array(jfspecs)) ||
 	(0 == json_array_size(jfspecs))) {
-      fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing filter specs.\n");
+      tr_debug("tr_cfg_parse_one_filter: Error parsing filter specs.");
       *rc = TR_CFG_NOPARSE;
       tr_filter_free(filt);
       return NULL;
     }
   
     if (TR_MAX_FILTER_SPECS < json_array_size(jfspecs)) {
-      fprintf(stderr, "tr_cfg_parse_one_filter: Filter has too many filter_specs, maximimum of %d.\n", TR_MAX_FILTER_SPECS);
+      tr_debug("tr_cfg_parse_one_filter: Filter has too many filter_specs, maximimum of %d.", TR_MAX_FILTER_SPECS);
       *rc = TR_CFG_NOPARSE;
       tr_filter_free(filt);
       return NULL;
     }
 
     if (NULL == (filt->lines[i] = talloc(trc, TR_FLINE))) {
-      fprintf(stderr, "tr_cfg_parse_one_filter: Out of memory (fline).\n");
+      tr_debug("tr_cfg_parse_one_filter: Out of memory (fline).");
       *rc = TR_CFG_NOMEM;
       tr_filter_free(filt);
       return NULL;
@@ -247,7 +286,7 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
       filt->lines[i]->action = TR_FILTER_ACTION_REJECT;
     }
     else {
-      fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing filter action, unknown action' %s'.\n", json_string_value(jfaction));
+      tr_debug("tr_cfg_parse_one_filter: Error parsing filter action, unknown action' %s'.", json_string_value(jfaction));
       *rc = TR_CFG_NOPARSE;
       tr_filter_free(filt);
       return NULL;
@@ -259,7 +298,7 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
 	(TR_MAX_CONST_MATCHES >= json_array_size(jrc))) {
 
       if (NULL == (filt->lines[i]->realm_cons = tr_cfg_parse_one_constraint(trc, "realm", jrc, rc))) {
-	fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing realm constraint");
+	tr_debug("tr_cfg_parse_one_filter: Error parsing realm constraint");
       tr_filter_free(filt);
       return NULL;
       }
@@ -271,7 +310,7 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
 	(TR_MAX_CONST_MATCHES >= json_array_size(jdc))) {
 
       if (NULL == (filt->lines[i]->domain_cons = tr_cfg_parse_one_constraint(trc, "domain", jdc, rc))) {
-	fprintf(stderr, "tr_cfg_parse_one_filter: Error parsing domain constraint");
+	tr_debug("tr_cfg_parse_one_filter: Error parsing domain constraint");
       tr_filter_free(filt);
       return NULL;
       }
@@ -284,14 +323,14 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
 	  (!json_is_string(jffield)) ||
 	  (NULL == (jfmatch = json_object_get(json_array_get(jfspecs, j), "match"))) ||
 	  (!json_is_string(jfmatch))) {
-	fprintf (stderr, "tr_cfg_parse_one_filter: Error parsing filter field and match for filter spec %d, filter line %d.\n", i, j);
+	tr_debug("tr_cfg_parse_one_filter: Error parsing filter field and match for filter spec %d, filter line %d.", i, j);
 	*rc = TR_CFG_NOPARSE;
 	tr_filter_free(filt);
 	return NULL;
       }
 
       if (NULL == (filt->lines[i]->specs[j] = talloc(trc, TR_FSPEC))) {
-	fprintf(stderr, "tr_cfg_parse_one_filter: Out of memory.\n");
+	tr_debug("tr_cfg_parse_one_filter: Out of memory.");
 	*rc = TR_CFG_NOMEM;
 	tr_filter_free(filt);
 	return NULL;
@@ -301,7 +340,7 @@ static TR_FILTER *tr_cfg_parse_one_filter (TR_CFG *trc, json_t *jfilt, TR_CFG_RC
     
       if ((NULL == (filt->lines[i]->specs[j]->field = tr_new_name((char *)json_string_value(jffield)))) ||
 	  (NULL == (filt->lines[i]->specs[j]->match = tr_new_name((char *)json_string_value(jfmatch))))) {
-	fprintf(stderr, "tr_cfg_parse_one_filter: Out of memory.\n");
+	tr_debug("tr_cfg_parse_one_filter: Out of memory.");
 	*rc = TR_CFG_NOMEM;
 	tr_filter_free(filt);
 	return NULL;
@@ -321,7 +360,7 @@ static TR_RP_CLIENT *tr_cfg_parse_one_rp_client (TR_CFG *trc, json_t *jrp, TR_CF
   int i = 0;
 
   if ((!trc) || (!jrp) || (!rc)) {
-    fprintf(stderr, "tr_cfg_parse_one_rp_realm: Bad parameters.\n");
+    tr_debug("tr_cfg_parse_one_rp_realm: Bad parameters.");
     if (rc)
       *rc = TR_CFG_BAD_PARAMS;
     return NULL;
@@ -329,14 +368,14 @@ static TR_RP_CLIENT *tr_cfg_parse_one_rp_client (TR_CFG *trc, json_t *jrp, TR_CF
 
   if ((NULL == (jgns = json_object_get(jrp, "gss_names"))) ||
       (!json_is_array(jgns))) {
-    fprintf(stderr, "tr_cfg_parse_one_rp_client: Error parsing RP client configuration, no GSS names.\n");
+    tr_debug("tr_cfg_parse_one_rp_client: Error parsing RP client configuration, no GSS names.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   /* TBD -- Support more than one filter per RP client? */
   if (NULL == (jfilt = json_object_get(jrp, "filter"))) {
-    fprintf(stderr, "tr_cfg_parse_one_rp_client: Error parsing RP client configuration, no filter.\n");
+    tr_debug("tr_cfg_parse_one_rp_client: Error parsing RP client configuration, no filter.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
@@ -345,19 +384,19 @@ static TR_RP_CLIENT *tr_cfg_parse_one_rp_client (TR_CFG *trc, json_t *jrp, TR_CF
   if ((NULL == (jftype = json_object_get(jfilt, "type"))) ||
       (!json_is_string(jftype)) ||
       (strcmp(json_string_value(jftype), "rp_permitted"))) {
-    fprintf(stderr, "tr_cfg_parse_one_rp_client: Error parsing RP client filter type.\n");
+    tr_debug("tr_cfg_parse_one_rp_client: Error parsing RP client filter type.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   if (TR_MAX_GSS_NAMES < json_array_size(jgns)) {
-    fprintf(stderr, "tr_cfg_parse_one_rp_client: RP Client has too many GSS Names.\n");
+    tr_debug("tr_cfg_parse_one_rp_client: RP Client has too many GSS Names.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   if (NULL == (rp = talloc(trc, TR_RP_CLIENT))) {
-    fprintf(stderr, "tr_cfg_parse_one_rp_realm: Out of memory.\n");
+    tr_debug("tr_cfg_parse_one_rp_realm: Out of memory.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -366,14 +405,14 @@ static TR_RP_CLIENT *tr_cfg_parse_one_rp_client (TR_CFG *trc, json_t *jrp, TR_CF
 
   /* TBD -- support more than one filter entry per RP Client? */
   if (NULL == (rp->filter = tr_cfg_parse_one_filter(trc, jfilt, rc))) {
-    fprintf(stderr, "tr_cfg_parse_one_rp_client: Error parsing filter.\n");
+    tr_debug("tr_cfg_parse_one_rp_client: Error parsing filter.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
     
   for (i = 0; i < json_array_size(jgns); i++) {
     if (NULL == (rp->gss_names[i] = tr_new_name ((char *)json_string_value(json_array_get(jgns, i))))) {
-      fprintf(stderr, "tr_cfg_parse_one_rp_client: No memory for GSS Name.\n");
+      tr_debug("tr_cfg_parse_one_rp_client: No memory for GSS Name.");
       *rc = TR_CFG_NOMEM;
       return NULL;
     }
@@ -403,7 +442,7 @@ static TR_CFG_RC tr_cfg_parse_rp_clients (TR_CFG *trc, json_t *jcfg) {
 						   &rc))) {
 	return rc;
       }
-      fprintf(stderr, "tr_cfg_parse_rp_clients: RP client configured -- first gss: %s\n", rp->gss_names[0]->buf);
+      tr_debug("tr_cfg_parse_rp_clients: RP client configured -- first gss: %s", rp->gss_names[0]->buf);
       rp->next = trc->rp_clients;
       trc->rp_clients = rp;
     }
@@ -415,13 +454,13 @@ static TR_AAA_SERVER *tr_cfg_parse_one_aaa_server (TR_CFG *trc, json_t *jaddr, T
   TR_AAA_SERVER *aaa = NULL;
 
   if ((!trc) || (!jaddr) || (!json_is_string(jaddr))) {
-    fprintf(stderr, "tr_cfg_parse_one_aaa_server: Bad parameters.\n");
+    tr_debug("tr_cfg_parse_one_aaa_server: Bad parameters.");
     *rc = TR_CFG_BAD_PARAMS;
     return NULL;
   }
 
   if (NULL == (aaa = talloc(trc, TR_AAA_SERVER))) {
-    fprintf(stderr, "tr_cfg_parse_one_aaa_server: Out of memory.\n");
+    tr_debug("tr_cfg_parse_one_aaa_server: Out of memory.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -444,7 +483,7 @@ static TR_AAA_SERVER *tr_cfg_parse_aaa_servers (TR_CFG *trc, json_t *jaaas, TR_C
       return NULL;
     }
     /* TBD -- IPv6 addresses */
-    //    fprintf(stderr, "tr_cfg_parse_aaa_servers: Configuring AAA Server: ip_addr = %s.\n", inet_ntoa(temp_aaa->aaa_server_addr));
+    //    tr_debug("tr_cfg_parse_aaa_servers: Configuring AAA Server: ip_addr = %s.", inet_ntoa(temp_aaa->aaa_server_addr));
     temp_aaa->next = aaa;
     aaa = temp_aaa;
   }
@@ -458,14 +497,14 @@ static TR_APC *tr_cfg_parse_apcs (TR_CFG *trc, json_t *japcs, TR_CFG_RC *rc)
   *rc = TR_CFG_SUCCESS;		/* presume success */
 
   if ((!trc) || (!japcs) || (!rc)) {
-    fprintf(stderr, "tr_cfg_parse_apcs: Bad parameters.\n");
+    tr_debug("tr_cfg_parse_apcs: Bad parameters.");
     if (rc) 
       *rc = TR_CFG_BAD_PARAMS;
     return NULL;
   }
 
   if (NULL == (apc = talloc(trc, TR_APC))) {
-    fprintf (stderr, "tr_cfg_parse_apcs: Out of memory.\n");
+    tr_debug("tr_cfg_parse_apcs: Out of memory.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -478,7 +517,7 @@ static TR_APC *tr_cfg_parse_apcs (TR_CFG *trc, json_t *japcs, TR_CFG_RC *rc)
     return NULL;
 
   if (NULL == (apc->id = tr_new_name((char *)json_string_value(json_array_get(japcs, 0))))) {
-    fprintf(stderr, "tr_cfg_parse_apcs: No memory for APC name.\n");
+    tr_debug("tr_cfg_parse_apcs: No memory for APC name.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -494,14 +533,14 @@ static TR_IDP_REALM *tr_cfg_parse_one_idp_realm (TR_CFG *trc, json_t *jidp, TR_C
   json_t *japcs = NULL;
 
   if ((!trc) || (!jidp) || (!rc)) {
-    fprintf(stderr, "tr_cfg_parse_one_idp_realm: Bad parameters.\n");
+    tr_debug("tr_cfg_parse_one_idp_realm: Bad parameters.");
     if (rc)
       *rc = TR_CFG_BAD_PARAMS;
     return NULL;
   }
 
   if (NULL == (idp = talloc(trc, TR_IDP_REALM))) {
-    fprintf(stderr, "tr_cfg_parse_one_idp_realm: Out of memory.\n");
+    tr_debug("tr_cfg_parse_one_idp_realm: Out of memory.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -514,7 +553,7 @@ static TR_IDP_REALM *tr_cfg_parse_one_idp_realm (TR_CFG *trc, json_t *jidp, TR_C
       (!json_is_string(jscfg)) ||
       (NULL == (jsrvrs = json_object_get(jidp, "aaa_servers"))) ||
       (!json_is_array(jsrvrs))) {
-    fprintf(stderr, "tr_cfg_parse_one_idp_realm: Error parsing IDP realm configuration.\n");
+    tr_debug("tr_cfg_parse_one_idp_realm: Error parsing IDP realm configuration.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
@@ -526,13 +565,13 @@ static TR_IDP_REALM *tr_cfg_parse_one_idp_realm (TR_CFG *trc, json_t *jidp, TR_C
   }
 
   if (NULL == (idp->realm_id = tr_new_name((char *)json_string_value(jrid)))) {
-    fprintf(stderr, "tr_cfg_parse_one_idp_realm: No memory for realm id.\n");
+    tr_debug("tr_cfg_parse_one_idp_realm: No memory for realm id.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
 
   if (NULL == (idp->aaa_servers = tr_cfg_parse_aaa_servers(trc, jsrvrs, rc))) {
-    fprintf(stderr, "tr_cfg_parse_one_idp_realm: Can't parse AAA servers for realm %s.\n", idp->realm_id->buf);
+    tr_debug("tr_cfg_parse_one_idp_realm: Can't parse AAA servers for realm %s.", idp->realm_id->buf);
     tr_free_name(idp->realm_id);
     return NULL;
   }
@@ -540,7 +579,7 @@ static TR_IDP_REALM *tr_cfg_parse_one_idp_realm (TR_CFG *trc, json_t *jidp, TR_C
   if ((NULL != (japcs = json_object_get(jidp, "apcs"))) &&
       (json_is_array(japcs))) {
     if (NULL == (idp->apcs = tr_cfg_parse_apcs(trc, japcs, rc))) {
-      fprintf(stderr, "tr_cfg_parse_one_idp_realm: Can't parse APCs for realm %s .\n", idp->realm_id->buf);
+      tr_debug("tr_cfg_parse_one_idp_realm: Can't parse APCs for realm %s .", idp->realm_id->buf);
       tr_free_name(idp->realm_id);
       /* TBD -- free aaa_servers */;
       return NULL;
@@ -570,7 +609,7 @@ static TR_CFG_RC tr_cfg_parse_default_servers (TR_CFG *trc, json_t *jcfg)
 						  &rc))) {
 	return rc;
       }
-      fprintf(stderr, "tr_cfg_parse_default_servers: Default server configured: %s\n", ds->hostname->buf);
+      tr_debug("tr_cfg_parse_default_servers: Default server configured: %s", ds->hostname->buf);
       ds->next = trc->default_servers;
       trc->default_servers = ds;
     }
@@ -598,7 +637,7 @@ static TR_CFG_RC tr_cfg_parse_idp_realms (TR_CFG *trc, json_t *jcfg)
 						    &rc))) {
 	return rc;
       }
-      fprintf(stderr, "tr_cfg_parse_idp_realms: IDP realm configured: %s.\n", idp->realm_id->buf);
+      tr_debug("tr_cfg_parse_idp_realms: IDP realm configured: %s.", idp->realm_id->buf);
       idp->next = trc->idp_realms;
       trc->idp_realms = idp;
     }
@@ -625,7 +664,7 @@ static TR_IDP_REALM *tr_cfg_parse_comm_idps (TR_CFG *trc, json_t *jidps, TR_CFG_
     if (NULL == (temp_idp = (tr_cfg_find_idp(trc, 
 					     tr_new_name((char *)json_string_value(json_array_get(jidps, i))), 
 					     rc)))) {
-      fprintf(stderr, "tr_cfg_parse_comm_idps: Unknown IDP %s.\n", 
+      tr_debug("tr_cfg_parse_comm_idps: Unknown IDP %s.", 
 	      (char *)json_string_value(json_array_get(jidps, i)));
       return NULL;
     }
@@ -653,7 +692,7 @@ static TR_RP_REALM *tr_cfg_parse_comm_rps (TR_CFG *trc, json_t *jrps, TR_CFG_RC 
 
   for (i = (json_array_size(jrps)-1); i >= 0; i--) {
     if (NULL == (temp_rp = talloc(trc, TR_RP_REALM))) {
-      fprintf(stderr, "tr_cfg_parse_comm_rps: Can't allocate memory for RP Realm.\n");
+      tr_debug("tr_cfg_parse_comm_rps: Can't allocate memory for RP Realm.");
       if (rc)
 	*rc = TR_CFG_NOMEM;
       return NULL;
@@ -661,7 +700,7 @@ static TR_RP_REALM *tr_cfg_parse_comm_rps (TR_CFG *trc, json_t *jrps, TR_CFG_RC 
     memset (temp_rp, 0, sizeof(TR_RP_REALM));
 
     if (NULL == (temp_rp->realm_name = tr_new_name((char *)json_string_value(json_array_get(jrps, i))))) {
-      fprintf(stderr, "tr_cfg_parse_comm_rps: No memory for RP Realm Name.\n");
+      tr_debug("tr_cfg_parse_comm_rps: No memory for RP Realm Name.");
       if (rc)
 	*rc = TR_CFG_NOMEM;
       return NULL;
@@ -683,14 +722,14 @@ static TR_COMM *tr_cfg_parse_one_comm (TR_CFG *trc, json_t *jcomm, TR_CFG_RC *rc
   json_t *jrps = NULL;
 
   if ((!trc) || (!jcomm) || (!rc)) {
-    fprintf(stderr, "tr_cfg_parse_one_comm: Bad parameters.\n");
+    tr_debug("tr_cfg_parse_one_comm: Bad parameters.");
     if (rc)
       *rc = TR_CFG_BAD_PARAMS;
     return NULL;
   }
 
   if (NULL == (comm = talloc(trc, TR_COMM))) {
-    fprintf(stderr, "tr_cfg_parse_one_comm: Out of memory.\n");
+    tr_debug("tr_cfg_parse_one_comm: Out of memory.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -707,13 +746,13 @@ static TR_COMM *tr_cfg_parse_one_comm (TR_CFG *trc, json_t *jcomm, TR_CFG_RC *rc
       (!json_is_array(jidps)) ||
       (NULL == (jrps = json_object_get(jcomm, "rp_realms"))) ||
       (!json_is_array(jrps))) {
-    fprintf(stderr, "tr_cfg_parse_one_comm: Error parsing Communities configuration.\n");
+    tr_debug("tr_cfg_parse_one_comm: Error parsing Communities configuration.");
     *rc = TR_CFG_NOPARSE;
     return NULL;
   }
 
   if (NULL == (comm->id = tr_new_name((char *)json_string_value(jid)))) {
-    fprintf(stderr, "tr_cfg_parse_one_comm: No memory for community id.\n");
+    tr_debug("tr_cfg_parse_one_comm: No memory for community id.");
     *rc = TR_CFG_NOMEM;
     return NULL;
   }
@@ -723,12 +762,12 @@ static TR_COMM *tr_cfg_parse_one_comm (TR_CFG *trc, json_t *jcomm, TR_CFG_RC *rc
   } else if (0 == strcmp(json_string_value(jtype), "coi")) {
     comm->type = TR_COMM_COI;
     if (NULL == (comm->apcs = tr_cfg_parse_apcs(trc, japcs, rc))) {
-      fprintf(stderr, "tr_cfg_parse_one_comm: Can't parse APCs for COI %s.\n", comm->id->buf);
+      tr_debug("tr_cfg_parse_one_comm: Can't parse APCs for COI %s.", comm->id->buf);
       tr_free_name(comm->id);
       return NULL;
     }
   } else {
-    fprintf(stderr, "tr_cfg_parse_one_comm: Invalid community type, comm = %s, type = %s\n", comm->id->buf, json_string_value(jtype));
+    tr_debug("tr_cfg_parse_one_comm: Invalid community type, comm = %s, type = %s", comm->id->buf, json_string_value(jtype));
     tr_free_name(comm->id);
     *rc = TR_CFG_NOPARSE;
     return NULL;
@@ -736,14 +775,14 @@ static TR_COMM *tr_cfg_parse_one_comm (TR_CFG *trc, json_t *jcomm, TR_CFG_RC *rc
 
   comm->idp_realms = tr_cfg_parse_comm_idps(trc, jidps, rc);
   if (TR_CFG_SUCCESS != *rc) {
-    fprintf(stderr, "tr_cfg_parse_one_comm: Can't parse IDP realms for comm %s.\n", comm->id->buf);
+    tr_debug("tr_cfg_parse_one_comm: Can't parse IDP realms for comm %s.", comm->id->buf);
     tr_free_name(comm->id);
     return NULL;
   }
 
   comm->rp_realms = tr_cfg_parse_comm_rps(trc, jrps, rc);
   if (TR_CFG_SUCCESS != *rc) {
-    fprintf(stderr, "tr_cfg_parse_comm: Can't parse RP realms for comm %s .\n", comm->id->buf);
+    tr_debug("tr_cfg_parse_comm: Can't parse RP realms for comm %s .", comm->id->buf);
     tr_free_name(comm->id);
     /* TBD -- free idps? */;
     return NULL;
@@ -760,7 +799,7 @@ static TR_CFG_RC tr_cfg_parse_comms (TR_CFG *trc, json_t *jcfg)
   int i = 0;
 
   if ((!trc) || (!jcfg)) {
-    fprintf(stderr, "tr_cfg_parse_comms: Bad Parameters.\n");
+    tr_debug("tr_cfg_parse_comms: Bad Parameters.");
     return TR_CFG_BAD_PARAMS;
   }
 
@@ -775,7 +814,7 @@ static TR_CFG_RC tr_cfg_parse_comms (TR_CFG *trc, json_t *jcfg)
 						&rc))) {
 	return rc;
       }
-      fprintf(stderr, "tr_cfg_parse_comms: Community configured: %s.\n", comm->id->buf);
+      tr_debug("tr_cfg_parse_comms: Community configured: %s.", comm->id->buf);
       comm->next = trc->comms;
       trc->comms = comm;
     }
@@ -791,22 +830,22 @@ TR_CFG_RC tr_cfg_validate (TR_CFG *trc) {
 
   if ((NULL == trc->internal)||
       (NULL == trc->internal->hostname)) {
-    fprintf(stderr, "tr_cfg_validate: Error: No internal configuration, or no hostname.\n");
+    tr_debug("tr_cfg_validate: Error: No internal configuration, or no hostname.");
     rc = TR_CFG_ERROR;
   }
 
   if (NULL == trc->rp_clients) {
-    fprintf(stderr, "tr_cfg_validate: Error: No RP Clients configured\n");
+    tr_debug("tr_cfg_validate: Error: No RP Clients configured");
     rc = TR_CFG_ERROR;
   }
 
   if (NULL == trc->comms) {
-    fprintf(stderr, "tr_cfg_validate: Error: No Communities configured\n");
+    tr_debug("tr_cfg_validate: Error: No Communities configured");
     rc = TR_CFG_ERROR;
   }
 
   if ((NULL == trc->default_servers) && (NULL == trc->idp_realms)) {
-    fprintf(stderr, "tr_cfg_validate: Error: No default servers or IDPs configured.\n");
+    tr_debug("tr_cfg_validate: Error: No default servers or IDPs configured.");
     rc = TR_CFG_ERROR;
   }
   
@@ -831,10 +870,10 @@ TR_CFG_RC tr_parse_config (TR_INSTANCE *tr, int n, struct dirent **cfg_files) {
 
   /* Parse configuration information from each config file */
   while (n--) {
-    fprintf(stderr, "tr_read_config: Parsing %s.\n", cfg_files[n]->d_name);
+    tr_debug("tr_read_config: Parsing %s.", cfg_files[n]->d_name);
     if (NULL == (jcfg = json_load_file(cfg_files[n]->d_name, 
 				       JSON_DISABLE_EOF_CHECK, &rc))) {
-      fprintf (stderr, "tr_read_config: Error parsing config file %s.\n", 
+      tr_debug("tr_read_config: Error parsing config file %s.", 
 	       cfg_files[n]->d_name);
       return TR_CFG_NOPARSE;
     }
@@ -851,7 +890,7 @@ TR_CFG_RC tr_parse_config (TR_INSTANCE *tr, int n, struct dirent **cfg_files) {
 
   /* make sure we got a complete, consistent configuration */
   if (TR_CFG_SUCCESS != tr_cfg_validate(tr->new_cfg)) {
-    fprintf(stderr, "tr_parse_config: Error: INVALID CONFIGURATION, EXITING\n");
+    tr_debug("tr_parse_config: Error: INVALID CONFIGURATION, EXITING");
     return TR_CFG_ERROR;
   }
 
@@ -871,7 +910,7 @@ TR_IDP_REALM *tr_cfg_find_idp (TR_CFG *tr_cfg, TR_NAME *idp_id, TR_CFG_RC *rc)
 
   for (cfg_idp = tr_cfg->idp_realms; NULL != cfg_idp; cfg_idp = cfg_idp->next) {
     if (!tr_name_cmp (idp_id, cfg_idp->realm_id)) {
-      fprintf(stderr, "tr_cfg_find_idp: Found %s.\n", idp_id->buf);
+      tr_debug("tr_cfg_find_idp: Found %s.", idp_id->buf);
       return cfg_idp;
     }
   }
@@ -893,7 +932,7 @@ TR_RP_CLIENT *tr_cfg_find_rp (TR_CFG *tr_cfg, TR_NAME *rp_gss, TR_CFG_RC *rc)
   for (cfg_rp = tr_cfg->rp_clients; NULL != cfg_rp; cfg_rp = cfg_rp->next) {
     for (i = 0; i < TR_MAX_GSS_NAMES; i++) {
       if (!tr_name_cmp (rp_gss, cfg_rp->gss_names[i])) {
-	fprintf(stderr, "tr_cfg_find_rp: Found %s.\n", rp_gss->buf);
+	tr_debug("tr_cfg_find_rp: Found %s.", rp_gss->buf);
 	return cfg_rp;
       }
     }
@@ -922,18 +961,18 @@ int tr_find_config_files (struct dirent ***cfg_files) {
 
   if (n < 0) {
     perror("scandir");
-    fprintf(stderr, "tr_find_config: scandir error.\n");
+    tr_debug("tr_find_config: scandir error.");
     return 0;
   }
 
   if (n == 0) {
-    fprintf (stderr, "tr_find_config: No config files found.\n");
+    tr_debug("tr_find_config: No config files found.");
     return 0;
   }
 
   i = n;
   while(i--) {
-    fprintf(stderr, "tr_find_config: Config file found (%s).\n", (*cfg_files)[i]->d_name);
+    tr_debug("tr_find_config: Config file found (%s).", (*cfg_files)[i]->d_name);
   }
     
   return n;

--- a/common/tr_debug.c
+++ b/common/tr_debug.c
@@ -231,8 +231,6 @@ void tr_log_close() {
 
 void tr_log(const int sev, const char *fmt, ...) {
 
-  tr_log_open();
-
   if (NULL != fmt) {
 
     va_list ap;
@@ -251,8 +249,6 @@ void tr_log(const int sev, const char *fmt, ...) {
 /* Convinience Functions */
 
 void tr_audit_resp(TID_RESP *resp) {
-
-  tr_log_open();
 
   if (NULL != resp) {
 
@@ -277,8 +273,6 @@ void tr_audit_resp(TID_RESP *resp) {
 }
 
 void tr_audit_req(TID_REQ *req) {
-
-  tr_log_open();
 
   if (NULL != req) {
 

--- a/common/tr_debug.c
+++ b/common/tr_debug.c
@@ -73,7 +73,11 @@ static void vfire_log(const int sev, const int facility, const char *fmt, va_lis
     char *buf = malloc(LOG_MAX_MESSAGE_SIZE);
     vsnprintf(buf, LOG_MAX_MESSAGE_SIZE, fmt, ap_copy);
 
-    syslog(LOG_MAKEPRI(facility, sev), "%s", buf);
+    /* syslog.h provides a macro for generating priorities, however in versions of glibc < 2.17 it is
+       broken if you use it as documented: https://sourceware.org/bugzilla/show_bug.cgi?id=14347
+       RHEL6 uses glibc 2.12, so do not use LOG_MAKEPRI until around 2020.
+    */
+    syslog((facility|sev), "%s", buf);
 
     free(buf);
   }

--- a/common/tr_debug.c
+++ b/common/tr_debug.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2014, JANET(UK)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JANET(UK) nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdlib.h>
+#include <syslog.h>
+#include <tr_debug.h>
+#include <tid_internal.h>
+
+#define LOG_MAX_MESSAGE_SIZE 65536
+#define LOG_FACILITY LOG_LOCAL5
+
+#define LOG_PREFIX "F-TICKS/abfab/1.0"
+#define LOG_OVERHEAD strlen(LOG_PREFIX)
+#define LOG_FIELD_SEP "#"
+#define LOG_MSG_TERMINATOR "#"
+#define LOG_KV_SEP "="
+#define AUDIT_FACILITY LOG_AUTHPRIV
+
+static int log_opened = 0;
+
+/* We'll be noisy until overriden */
+static int log_threshold = LOG_DEBUG;
+static int console_threshold = LOG_DEBUG;
+
+static void vfire_log(const int sev, const int facility, const char *fmt, va_list ap) {
+
+   /* if we want to use ap twice, we need to duplicate it before the first use */
+   va_list ap_copy;
+   va_copy(ap_copy, ap);
+
+  /* write messages to stderr if they are more severe than the threshold and are not audit messages */
+  if ((sev <= console_threshold) && (facility != AUDIT_FACILITY)) {
+
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+  }
+
+  /* write messages to syslog if they are more severe than the threshold or are audit messages */
+  if (sev <= log_threshold || (facility == AUDIT_FACILITY)) {
+
+    /* Make sure that the message will fit, truncate if necessary */
+    char *buf = malloc(LOG_MAX_MESSAGE_SIZE);
+    vsnprintf(buf, LOG_MAX_MESSAGE_SIZE, fmt, ap_copy);
+
+    syslog(LOG_MAKEPRI(facility, sev), "%s", buf);
+
+    free(buf);
+  }
+
+  va_end(ap_copy);
+}
+
+static void fire_log(const int sev, const int facility, const char *fmt, ...) {
+  va_list ap;
+
+  va_start(ap, fmt);
+  vfire_log(sev, facility, fmt, ap);
+  va_end(ap);
+}
+
+static char *audit_fmt(const char *key, char *value) {
+
+  if (NULL != key) {
+
+    /* Rewrite any NULL's to "nones" */
+    char *val = NULL == value ? "none" : value;
+
+    size_t len = strlen(key)
+               + strlen(val)
+               + strlen(LOG_FIELD_SEP)
+               + strlen(LOG_KV_SEP)
+               + 1;
+
+    char *buf = malloc(len);
+
+    snprintf(buf, len, "%s%s%s%s", LOG_FIELD_SEP, key, LOG_KV_SEP, val);
+
+    return buf;
+  }
+  else {
+
+    tr_debug("audit_fmt: Message dropped, null pointer passed.");
+    return NULL;
+  }
+}
+
+static void free_array(const int count, char *array[]) {
+
+   int i;
+
+   for(i = 0; i < count; i++) {
+      free(array[i]);
+   }
+}
+
+static char *join_audit_msg(const int count, char *array[]) {
+
+  int i;
+  int len = 1; /* start at one to account for terminator */
+
+  /* evaluate length of concatenated string */
+  for(i = 0; i < count; i++) {
+
+    if ((len + strlen(array[i]) + LOG_OVERHEAD) <= LOG_MAX_MESSAGE_SIZE) {
+
+      len += strlen(array[i]);
+    }
+  }
+
+  int remain = len - 1;
+  char *buf = (char *) calloc(len, sizeof(char));
+
+  /* join fields up to count */
+  for(i = 0; i < count; i++) {
+
+    if ((strlen(buf) + strlen(array[i]) + LOG_OVERHEAD + 1) <= LOG_MAX_MESSAGE_SIZE) {
+
+      strncat(buf, array[i], remain);
+      remain -= strlen(array[i]);
+    }
+    else {
+
+      tr_debug("join_audit_msg: Attribute dropped, too long.");
+    }
+  }
+
+  return buf;
+}
+
+int str2sev(const char* sev) {
+
+  if (strcmp(sev, "debug")) {
+
+    return LOG_DEBUG;
+  }
+  else if (strcmp(sev, "info")) {
+
+    return LOG_INFO;
+  }
+  else if (strcmp(sev, "notice")) {
+
+    return LOG_NOTICE;
+  }
+  else if (strcmp(sev, "warning")) {
+
+    return LOG_WARNING;
+  }
+  else if (strcmp(sev, "err")) {
+
+    return LOG_ERR;
+  }
+  else if (strcmp(sev, "crit")) {
+
+    return LOG_CRIT;
+  }
+  else if (strcmp(sev, "alert")) {
+
+    return LOG_ALERT;
+  }
+  else if (strcmp(sev, "emerg")) {
+
+    return LOG_EMERG;
+  }
+
+  tr_debug("str2sev: invalid severity specified: %s, logging everything", sev);
+
+  return LOG_DEBUG;
+}
+
+void tr_log_threshold(const int sev) {
+
+  log_threshold = sev;
+  return;
+}
+
+void tr_console_threshold(const int sev) {
+
+  console_threshold = sev;
+  return;
+}
+
+void tr_log_open() {
+
+  if (!log_opened) {
+
+    openlog(NULL, LOG_PID | LOG_NDELAY, LOG_FACILITY);
+    log_opened = 1;
+  }
+}
+
+void tr_log_close() {
+
+    closelog();
+    log_opened = 0;
+}
+
+void tr_log(const int sev, const char *fmt, ...) {
+
+  tr_log_open();
+
+  if (NULL != fmt) {
+
+    va_list ap;
+    va_start(ap, fmt);
+
+    vfire_log(sev, LOG_FACILITY, fmt, ap);
+
+    va_end(ap);
+  }
+  else {
+
+          tr_debug("tr_log: Message dropped, null pointer passed.");
+  }
+}
+
+/* Convinience Functions */
+
+void tr_audit_resp(TID_RESP *resp) {
+
+  tr_log_open();
+
+  if (NULL != resp) {
+
+    char *attrs[] = { audit_fmt("result", resp->result ? "error" : "success"),
+                      audit_fmt("comm", NULL != resp->comm ? resp->comm->buf : NULL),
+                      audit_fmt("rp_realm", NULL != resp->rp_realm ? resp->rp_realm->buf : NULL),
+                      audit_fmt("realm", NULL != resp->realm ? resp->realm->buf : NULL),
+                      audit_fmt("err", NULL != resp->err_msg ? resp->err_msg->buf : NULL)
+                    };
+
+    char *msg = join_audit_msg(sizeof(attrs) / sizeof(attrs[0]), attrs);
+    free_array(sizeof(attrs) / sizeof(attrs[0]), attrs);
+
+    fire_log(LOG_INFO, AUDIT_FACILITY, "%s%s%s", LOG_PREFIX, msg, LOG_MSG_TERMINATOR);
+
+    free(msg);
+  }
+  else {
+
+    tr_debug("tr_audit_resp: Message dropped, null pointer passed.");
+  }
+}
+
+void tr_audit_req(TID_REQ *req) {
+
+  tr_log_open();
+
+  if (NULL != req) {
+
+    char *attrs[] = { audit_fmt("comm", NULL != req->comm ? req->comm->buf : NULL),
+                      audit_fmt("rp_realm", NULL != req->rp_realm ? req->rp_realm->buf : NULL),
+                      audit_fmt("realm", NULL != req->realm ? req->realm->buf : NULL),
+                    };
+
+    char *msg = join_audit_msg(sizeof(attrs) / sizeof(attrs[0]), attrs);
+    free_array(sizeof(attrs) / sizeof(attrs[0]), attrs);
+
+    fire_log(LOG_INFO, AUDIT_FACILITY, "%s%s%s", LOG_PREFIX, msg, LOG_MSG_TERMINATOR);
+
+    free(msg);
+  }
+  else {
+
+        tr_debug("tr_audit_req: Message dropped, null pointer passed.");
+  }
+}

--- a/common/tr_dh.c
+++ b/common/tr_dh.c
@@ -39,6 +39,7 @@
 #include <talloc.h>
 #include <assert.h>
 #include <tid_internal.h>
+#include <tr_debug.h>
 
 
 unsigned char tr_2048_dhprime[2048/8] = {
@@ -102,23 +103,23 @@ DH *tr_create_dh_params(unsigned char *priv_key,
 
   DH_check(dh, &dh_err);
   if (0 != dh_err) {
-    fprintf(stderr, "Warning: dh_check failed with %d", dh_err);
+    tr_warning("Warning: dh_check failed with %d", dh_err);
     if (dh_err & DH_CHECK_P_NOT_PRIME)
-      fprintf(stderr, ": p value is not prime\n");
+      tr_warning(": p value is not prime");
     else if (dh_err & DH_CHECK_P_NOT_SAFE_PRIME)
-      fprintf(stderr, ": p value is not a safe prime\n");
+      tr_warning(": p value is not a safe prime");
     else if (dh_err & DH_UNABLE_TO_CHECK_GENERATOR)
-      fprintf(stderr, ": unable to check the generator value\n");
+      tr_warning(": unable to check the generator value");
     else if (dh_err & DH_NOT_SUITABLE_GENERATOR)
-      fprintf (stderr, ": the g value is not a generator\n");
-    else 
-      fprintf(stderr, "\n");
+      tr_warning(": the g value is not a generator");
+    else
+      tr_warning("unhandled error %i", dh_err);
   }
-  
+
   return(dh);
 }
 
-DH *tr_create_matching_dh (unsigned char *priv_key, 
+DH *tr_create_matching_dh (unsigned char *priv_key,
 			   size_t keylen,
 			   DH *in_dh) {
   DH *dh = NULL;
@@ -128,14 +129,14 @@ DH *tr_create_matching_dh (unsigned char *priv_key,
     return NULL;
 
   if (NULL == (dh = DH_new())) {
-    fprintf(stderr, "Unable to allocate new DH structure.\n");
+    tr_crit("tr_create_matching_dh: unable to allocate new DH structure.");
     return NULL;
   }
 
   if ((NULL == (dh->g = BN_dup(in_dh->g))) ||
       (NULL == (dh->p = BN_dup(in_dh->p)))) {
     DH_free(dh);
-    fprintf(stderr, "Invalid dh parameter values, can't be duped.\n");
+    tr_debug("tr_create_matching_dh: Invalid dh parameter values, can't be duped.");
     return NULL;
   }
 
@@ -146,19 +147,19 @@ DH *tr_create_matching_dh (unsigned char *priv_key,
   DH_generate_key(dh);		/* generates the public key */
   DH_check(dh, &dh_err);
   if (0 != dh_err) {
-    fprintf(stderr, "Warning: dh_check failed with %d", dh_err);
+    tr_warning("Warning: dh_check failed with %d", dh_err);
     if (dh_err & DH_CHECK_P_NOT_PRIME)
-      fprintf(stderr, ": p value is not prime\n");
+      tr_warning(": p value is not prime");
     else if (dh_err & DH_CHECK_P_NOT_SAFE_PRIME)
-      fprintf(stderr, ": p value is not a safe prime\n");
+      tr_warning(": p value is not a safe prime");
     else if (dh_err & DH_UNABLE_TO_CHECK_GENERATOR)
-      fprintf(stderr, ": unable to check the generator value\n");
+      tr_warning(": unable to check the generator value");
     else if (dh_err & DH_NOT_SUITABLE_GENERATOR)
-      fprintf (stderr, ": the g value is not a generator\n");
-    else 
-      fprintf(stderr, "\n");
+      tr_warning(": the g value is not a generator");
+    else
+      tr_warning("unhandled error %i", dh_err);
   }
-  
+
   return(dh);
 }
 
@@ -179,14 +180,14 @@ int tr_compute_dh_key(unsigned char **pbuf,
   if ((!pbuf) || 
       (!pub_key) || 
       (!priv_dh)) {
-    fprintf(stderr, "tr_compute_dh_key(): Invalid parameters.\n");
+    tr_debug("tr_compute_dh_key: Invalid parameters.");
     return(-1);
   }
   *pbuf = NULL;
   buflen = DH_size(priv_dh);
   buf = malloc(buflen);
   if (buf == NULL) {
-    fprintf(stderr, "out of memory\n");
+    tr_crit("tr_compute_dh_key: out of memory");
     return -1;
   }
 

--- a/common/tr_msg.c
+++ b/common/tr_msg.c
@@ -113,7 +113,7 @@ static DH *tr_msg_decode_dh(json_t *jdh)
   json_t *jpub_key = NULL;
 
   if (!(dh = malloc(sizeof(DH)))) {
-    fprintf (stderr, "tr_msg_decode_dh(): Error allocating DH structure.\n");
+    tr_crit("tr_msg_decode_dh(): Error allocating DH structure.");
     return NULL;
   }
  
@@ -123,7 +123,7 @@ static DH *tr_msg_decode_dh(json_t *jdh)
   if ((NULL == (jp = json_object_get(jdh, "dh_p"))) ||
       (NULL == (jg = json_object_get(jdh, "dh_g"))) ||
       (NULL == (jpub_key = json_object_get(jdh, "dh_pub_key")))) {
-    fprintf (stderr, "tr_msg_decode_dh(): Error parsing dh_info.\n");
+    tr_debug("tr_msg_decode_dh(): Error parsing dh_info.");
     free(dh);
     return NULL;
   }
@@ -177,7 +177,7 @@ static TID_REQ *tr_msg_decode_tidreq(json_t *jreq)
   json_t *jdh = NULL;
 
   if (!(treq =tid_req_new())) {
-    fprintf (stderr, "tr_msg_decode_tidreq(): Error allocating TID_REQ structure.\n");
+    tr_crit("tr_msg_decode_tidreq(): Error allocating TID_REQ structure.");
     return NULL;
   }
  
@@ -185,7 +185,7 @@ static TID_REQ *tr_msg_decode_tidreq(json_t *jreq)
   if ((NULL == (jrp_realm = json_object_get(jreq, "rp_realm"))) ||
       (NULL == (jrealm = json_object_get(jreq, "target_realm"))) ||
       (NULL == (jcomm = json_object_get(jreq, "community")))) {
-    fprintf (stderr, "tr_msg_decode(): Error parsing required fields.\n");
+    tr_debug("tr_msg_decode(): Error parsing required fields.");
     tid_req_free(treq);
     return NULL;
   }
@@ -196,7 +196,7 @@ static TID_REQ *tr_msg_decode_tidreq(json_t *jreq)
 
   /* Get DH Info from the request */
   if (NULL == (jdh = json_object_get(jreq, "dh_info"))) {
-    fprintf (stderr, "tr_msg_decode(): Error parsing dh_info.\n");
+    tr_debug("tr_msg_decode(): Error parsing dh_info.");
     tid_req_free(treq);
     return NULL;
   }
@@ -210,7 +210,7 @@ static TID_REQ *tr_msg_decode_tidreq(json_t *jreq)
   treq->cons = (TR_CONSTRAINT_SET *) json_object_get(jreq, "constraints");
   if (treq->cons) {
     if (!tr_constraint_set_validate(treq->cons)) {
-      tr_debug("Constraint set validation failed\n");
+      tr_debug("Constraint set validation failed");
     tid_req_free(treq);
     return NULL;
     }
@@ -225,7 +225,7 @@ static json_t *tr_msg_encode_one_server(TID_SRVR_BLK *srvr)
   json_t *jsrvr = NULL;
   json_t *jstr = NULL;
 
-  fprintf(stderr, "Encoding one server.\n");
+  tr_debug("Encoding one server.");
 
   jsrvr = json_object();
 
@@ -238,8 +238,8 @@ static json_t *tr_msg_encode_one_server(TID_SRVR_BLK *srvr)
   json_object_set_new(jsrvr, "key_name", jstr);
   json_object_set_new(jsrvr, "server_dh", tr_msg_encode_dh(srvr->aaa_server_dh));
   
-  //  fprintf(stderr,"tr_msg_encode_one_server(): jsrvr contains:\n");
-  //  fprintf(stderr,"%s\n", json_dumps(jsrvr, 0));
+  //  tr_debug("tr_msg_encode_one_server(): jsrvr contains:");
+  //  tr_debug("%s", json_dumps(jsrvr, 0));
   return jsrvr;
 }
 
@@ -256,7 +256,7 @@ static int tr_msg_decode_one_server(json_t *jsrvr, TID_SRVR_BLK *srvr)
   if ((NULL == (jsrvr_addr = json_object_get(jsrvr, "server_addr"))) ||
       (NULL == (jsrvr_kn = json_object_get(jsrvr, "key_name"))) ||
       (NULL == (jsrvr_dh = json_object_get(jsrvr, "server_dh")))) {
-    tr_debug("tr_msg_decode_one_server(): Error parsing required fields.\n");
+    tr_debug("tr_msg_decode_one_server(): Error parsing required fields.");
     return -1;
   }
   
@@ -283,8 +283,8 @@ static json_t *tr_msg_encode_servers(TID_RESP *resp)
     }
   }
 
-  //  fprintf(stderr,"tr_msg_encode_servers(): servers contains:\n");
-  //  fprintf(stderr,"%s\n", json_dumps(jservers, 0));
+  //  tr_debug("tr_msg_encode_servers(): servers contains:");
+  //  tr_debug("%s", json_dumps(jservers, 0));
   return jservers;
 }
 
@@ -295,13 +295,13 @@ static TID_SRVR_BLK *tr_msg_decode_servers(void * ctx, json_t *jservers, size_t 
   size_t i, num_servers;
 
   num_servers = json_array_size(jservers);
-  fprintf(stderr, "tr_msg_decode_servers(): Number of servers = %u.\n", (unsigned) num_servers);
+  tr_debug("tr_msg_decode_servers(): Number of servers = %u.", (unsigned) num_servers);
   
   if (0 == num_servers) {
-    fprintf(stderr, "tr_msg_decode_servers(): Server array is empty.\n"); 
+    tr_debug("tr_msg_decode_servers(): Server array is empty."); 
     return NULL;
   }
-    servers = talloc_zero_array(ctx, TID_SRVR_BLK, num_servers);
+  servers = talloc_zero_array(ctx, TID_SRVR_BLK, num_servers);
 
   for (i = 0; i < num_servers; i++) {
     jsrvr = json_array_get(jservers, i);
@@ -355,7 +355,7 @@ static json_t * tr_msg_encode_tidresp(TID_RESP *resp)
   }
 
   if (NULL == resp->servers) {
-    fprintf(stderr, "tr_msg_encode_tidresp(): No servers to encode.\n");
+    tr_debug("tr_msg_encode_tidresp(): No servers to encode.");
     return jresp;
   }
   jservers = tr_msg_encode_servers(resp);
@@ -376,7 +376,7 @@ static TID_RESP *tr_msg_decode_tidresp(json_t *jresp)
   json_t *jerr_msg = NULL;
 
   if (!(tresp = talloc_zero(NULL, TID_RESP))) {
-    fprintf (stderr, "tr_msg_decode_tidresp(): Error allocating TID_RESP structure.\n");
+    tr_crit("tr_msg_decode_tidresp(): Error allocating TID_RESP structure.");
     return NULL;
   }
  
@@ -390,13 +390,13 @@ static TID_RESP *tr_msg_decode_tidresp(json_t *jresp)
       (!json_is_string(jrealm)) ||
       (NULL == (jcomm = json_object_get(jresp, "comm"))) ||
       (!json_is_string(jcomm))) {
-    fprintf (stderr, "tr_msg_decode_tidresp(): Error parsing response.\n");
+    tr_debug("tr_msg_decode_tidresp(): Error parsing response.");
     talloc_free(tresp);
     return NULL;
   }
 
   if (0 == (strcmp(json_string_value(jresult), "success"))) {
-    fprintf(stderr, "tr_msg_decode_tidresp(): Success! result = %s.\n", json_string_value(jresult));
+    tr_debug("tr_msg_decode_tidresp(): Success! result = %s.", json_string_value(jresult));
     if ((NULL != (jservers = json_object_get(jresp, "servers"))) ||
 	(!json_is_array(jservers))) {
       tresp->servers = tr_msg_decode_servers(tresp, jservers, &tresp->num_servers); 
@@ -409,7 +409,7 @@ static TID_RESP *tr_msg_decode_tidresp(json_t *jresp)
   }
   else {
     tresp->result = TID_ERROR;
-    fprintf(stderr, "tr_msg_decode_tidresp(): Error! result = %s.\n", json_string_value(jresult));
+    tr_debug("tr_msg_decode_tidresp(): Error! result = %s.", json_string_value(jresult));
     if ((NULL != (jerr_msg = json_object_get(jresp, "err_msg"))) ||
 	(!json_is_string(jerr_msg))) {
       tresp->err_msg = tr_new_name((char *)json_string_value(jerr_msg));
@@ -471,12 +471,12 @@ TR_MSG *tr_msg_decode(char *jbuf, size_t buflen)
   const char *mtype = NULL;
 
   if (NULL == (jmsg = json_loadb(jbuf, buflen, JSON_DISABLE_EOF_CHECK, &rc))) {
-    fprintf (stderr, "tr_msg_decode(): error loading object\n");
+    tr_debug("tr_msg_decode(): error loading object");
     return NULL;
   }
 
   if (!(msg = malloc(sizeof(TR_MSG)))) {
-    fprintf (stderr, "tr_msg_decode(): Error allocating TR_MSG structure.\n");
+    tr_debug("tr_msg_decode(): Error allocating TR_MSG structure.");
     json_decref(jmsg);
     return NULL;
   }
@@ -485,7 +485,7 @@ TR_MSG *tr_msg_decode(char *jbuf, size_t buflen)
 
   if ((NULL == (jtype = json_object_get(jmsg, "msg_type"))) ||
       (NULL == (jbody = json_object_get(jmsg, "msg_body")))) {
-    fprintf (stderr, "tr_msg_decode(): Error parsing message header.\n");
+    tr_debug("tr_msg_decode(): Error parsing message header.");
     json_decref(jmsg);
     tr_msg_free_decoded(msg);
     return NULL;

--- a/common/tr_rp.c
+++ b/common/tr_rp.c
@@ -36,13 +36,14 @@
 #include <tr_rp.h>
 #include <tr_config.h>
 #include <tr.h>
+#include <tr_debug.h>
 
 TR_RP_CLIENT *tr_rp_client_lookup(TR_INSTANCE *tr, TR_NAME *gss_name) {
   TR_RP_CLIENT *rp = NULL;
   int i = 0;
 
   if ((!tr) || (!tr->active_cfg) || (!gss_name)) {
-    fprintf(stderr, "tr_rp_client_lookup: Bad parameters.\n");
+    tr_debug("tr_rp_client_lookup: Bad parameters.");
     return NULL;
   }
 

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,6 @@ AC_CHECK_LIB([sqlite3], [sqlite3_open],,
     [AC_MSG_ERROR([Please install sqlite3 development])])
 AC_CHECK_LIB([jansson], [json_object])
 AC_CHECK_LIB([crypto], [DH_new])
-AC_CHECK_HEADERS(gssapi.h gssapi_ext.h jansson.h talloc.h openssl/dh.h openssl/bn.h)
+AC_CHECK_HEADERS(gssapi.h gssapi_ext.h jansson.h talloc.h openssl/dh.h openssl/bn.h syslog.h)
 AC_CONFIG_FILES([Makefile gsscon/Makefile])
 AC_OUTPUT

--- a/include/tr_config.h
+++ b/include/tr_config.h
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <dirent.h>
 #include <jansson.h>
+#include <syslog.h>
 
 #include <tr.h>
 #include <tr_rp.h>
@@ -47,6 +48,8 @@
 #define TR_DEFAULT_MAX_TREE_DEPTH 12
 #define TR_DEFAULT_TR_PORT 12308
 #define TR_DEFAULT_TIDS_PORT 12309
+#define TR_DEFAULT_LOG_THRESHOLD LOG_INFO
+#define TR_DEFAULT_CONSOLE_THRESHOLD LOG_NOTICE
 
 typedef enum tr_cfg_rc {
   TR_CFG_SUCCESS = 0,	/* No error */
@@ -60,6 +63,8 @@ typedef struct tr_cfg_internal {
   unsigned int max_tree_depth;
   unsigned int tids_port;
   const char *hostname;
+  int log_threshold;
+  int console_threshold;
 } TR_CFG_INTERNAL;
 
 typedef struct tr_cfg {

--- a/include/tr_debug.h
+++ b/include/tr_debug.h
@@ -35,6 +35,28 @@
 #ifndef _TR_DEBUG_H
 #define _TR_DEBUG_H
 
-#define tr_debug(...) fprintf( stderr, __VA_ARGS__)
+#include <syslog.h>
+#include <trust_router/tr_versioning.h>
+#include <tid_internal.h>
+
+/* Log macros according to severity levels */
+
+#define tr_emerg(...)   tr_log(LOG_EMERG, __VA_ARGS__)
+#define tr_alert(...)   tr_log(LOG_ALERT, __VA_ARGS__)
+#define tr_crit(...)    tr_log(LOG_CRIT, __VA_ARGS__)
+#define tr_err(...)     tr_log(LOG_ERR, __VA_ARGS__)
+#define tr_warning(...) tr_log(LOG_WARNING, __VA_ARGS__)
+#define tr_notice(...)  tr_log(LOG_NOTICE, __VA_ARGS__)
+#define tr_info(...)    tr_log(LOG_INFO, __VA_ARGS__)
+#define tr_debug(...)   tr_log(LOG_DEBUG, __VA_ARGS__)
+
+TR_EXPORT int str2sev(const char *sev);
+TR_EXPORT void tr_log_threshold(const int sev);
+TR_EXPORT void tr_console_threshold(const int sev);
+TR_EXPORT void tr_log_open(void);
+TR_EXPORT void tr_log_close(void);
+TR_EXPORT void tr_log(const int sev, const char *fmt, ...);
+TR_EXPORT void tr_audit_resp(TID_RESP *resp);
+TR_EXPORT void tr_audit_req(TID_REQ *req);
 
 #endif

--- a/redhat/default-main.cfg
+++ b/redhat/default-main.cfg
@@ -1,5 +1,9 @@
-{"tr_internal":{"max_tree_depth": 4,
-                "hostname":"tr.moonshot.local",
-		"tids_port" : 12309
-               }
+{"tr_internal": {"max_tree_depth": 4,
+		 "hostname":"tr.moonshot.local",
+		 "tids_port": 12309,
+
+		 "logging": { "console_threshold": "debug",
+			      "log_threshold": "info"
+			    }
+		}
 }

--- a/tid/example/tidc_main.c
+++ b/tid/example/tidc_main.c
@@ -99,6 +99,9 @@ int main (int argc,
   int rc;
   gss_ctx_id_t gssctx;
 
+  /* Use standalone logging */
+  tr_log_open();
+
   /* set logging levels */
   talloc_set_log_stderr();
   tr_log_threshold(LOG_CRIT);

--- a/tid/example/tidc_main.c
+++ b/tid/example/tidc_main.c
@@ -37,6 +37,7 @@
 #include <talloc.h>
 
 #include <gsscon.h>
+#include <tr_debug.h>
 #include <tid_internal.h>
 #include <trust_router/tr_dh.h>
 
@@ -98,7 +99,11 @@ int main (int argc,
   int rc;
   gss_ctx_id_t gssctx;
 
+  /* set logging levels */
   talloc_set_log_stderr();
+  tr_log_threshold(LOG_CRIT);
+  tr_console_threshold(LOG_DEBUG);
+
   /* Parse command-line arguments */ 
   if (argc < 5 || argc > 6) {
     tidc_print_usage(argv[0]);

--- a/tid/example/tids_main.c
+++ b/tid/example/tids_main.c
@@ -104,7 +104,7 @@ static int handle_authorizations(TID_REQ *req, const unsigned char *dh_hash,
   int sqlite3_result;
 
   if (!req->cons) {
-    tr_debug("Request has no constraints, so no authorizations.\n");
+    tr_debug("Request has no constraints, so no authorizations.");
     return 0;
   }
   intersected = tr_constraint_set_intersect(req, req->cons);
@@ -118,17 +118,17 @@ static int handle_authorizations(TID_REQ *req, const unsigned char *dh_hash,
 					       intersected, "realm",
 					       &realm_wc, &realm_len))
     return -1;
-  tr_debug(" %u domain constraint matches and %u realm constraint matches\n",
+  tr_debug(" %u domain constraint matches and %u realm constraint matches",
 	   (unsigned) domain_len, (unsigned) realm_len);
   if (0 != sqlify_wc(req, domain_wc, domain_len, &error)) {
-    tr_debug("Processing domain constraints: %s\n", error);
+    tr_debug("Processing domain constraints: %s", error);
     return -1;
   }else if (0 != sqlify_wc(req, realm_wc, realm_len, &error)) {
-    tr_debug("Processing realm constraints: %s\n", error);
+    tr_debug("Processing realm constraints: %s", error);
     return -1;
   }
   if (!authorization_insert) {
-    tr_debug( " No database, no authorizations inserted\n");
+    tr_debug( " No database, no authorizations inserted");
     return 0;
   }
   for (domain_index = 0; domain_index < domain_len; domain_index++)
@@ -143,7 +143,7 @@ static int handle_authorizations(TID_REQ *req, const unsigned char *dh_hash,
       sqlite3_bind_text(authorization_insert, 5, req->comm->buf, req->comm->len, SQLITE_TRANSIENT);
       sqlite3_result = sqlite3_step(authorization_insert);
       if (SQLITE_DONE != sqlite3_result)
-	printf("sqlite3: failed to write to database\n");
+	tr_crit("sqlite3: failed to write to database");
       sqlite3_reset(authorization_insert);
     }
   return 0;
@@ -162,18 +162,18 @@ static int tids_req_handler (TIDS_INSTANCE *tids,
   size_t pub_digest_len;
   
 
-  fprintf(stdout, "tids_req_handler: Request received! target_realm = %s, community = %s\n", req->realm->buf, req->comm->buf);
+  tr_debug("tids_req_handler: Request received! target_realm = %s, community = %s", req->realm->buf, req->comm->buf);
   if (tids)
     tids->req_count++;
 
   if (!(resp) || !resp) {
-    fprintf(stderr, "tids_req_handler: No response structure.\n");
+    tr_debug("tids_req_handler: No response structure.");
     return -1;
   }
 
   /* Allocate a new server block */
   if (NULL == (resp->servers = malloc(sizeof(TID_SRVR_BLK)))){
-    fprintf(stderr, "tids_req_handler(): malloc failed.\n");
+    tr_crit("tids_req_handler(): malloc failed.");
     return -1;
   }
   memset(resp->servers, 0, sizeof(TID_SRVR_BLK));
@@ -182,12 +182,12 @@ static int tids_req_handler (TIDS_INSTANCE *tids,
   /* TBD -- Set up the server IP Address */
 
   if (!(req) || !(req->tidc_dh)) {
-    fprintf(stderr, "tids_req_handler(): No client DH info.\n");
+    tr_debug("tids_req_handler(): No client DH info.");
     return -1;
   }
 
   if ((!req->tidc_dh->p) || (!req->tidc_dh->g)) {
-    fprintf(stderr, "tids_req_handler(): NULL dh values.\n");
+    tr_debug("tids_req_handler: NULL dh values.");
     return -1;
   }
 
@@ -196,12 +196,12 @@ static int tids_req_handler (TIDS_INSTANCE *tids,
   // fprintf(stderr, "...from client DH block, dh_g = %s, dh_p = %s.\n", BN_bn2hex(req->tidc_dh->g), BN_bn2hex(req->tidc_dh->p));
 
   if (NULL == (resp->servers->aaa_server_dh = tr_create_matching_dh(NULL, 0, req->tidc_dh))) {
-    fprintf(stderr, "tids_req_handler(): Can't create server DH params.\n");
+    tr_debug("tids_req_handler: Can't create server DH params.");
     return -1;
   }
 
   if (0 == inet_aton(tids->ipaddr, &(resp->servers->aaa_server_addr))) {
-    fprintf(stderr, "tids_req_handler(): inet_aton() failed.\n");
+    tr_debug("tids_req_handler: inet_aton() failed.");
     return -1;
   }
 
@@ -216,12 +216,12 @@ static int tids_req_handler (TIDS_INSTANCE *tids,
   if (0 > (s_keylen = tr_compute_dh_key(&s_keybuf, 
 					req->tidc_dh->pub_key, 
 				        resp->servers->aaa_server_dh))) {
-    fprintf(stderr, "tids_req_handler(): Key computation failed.");
+    tr_debug("tids_req_handler: Key computation failed.");
     return -1;
   }
   if (0 != tr_dh_pub_hash(req,
 			  &pub_digest, &pub_digest_len)) {
-    tr_debug("Unable to digest client public key\n");
+    tr_debug("tids_req_handler: Unable to digest client public key");
     return -1;
   }
   if (0 != handle_authorizations(req, pub_digest, pub_digest_len))
@@ -233,7 +233,7 @@ static int tids_req_handler (TIDS_INSTANCE *tids,
     sqlite3_bind_blob(insert_stmt, 3, pub_digest, pub_digest_len, SQLITE_TRANSIENT);
     sqlite3_result = sqlite3_step(insert_stmt);
     if (SQLITE_DONE != sqlite3_result)
-      printf("sqlite3: failed to write to database\n");
+      tr_crit("sqlite3: failed to write to database");
     sqlite3_reset(insert_stmt);
   }
   
@@ -269,11 +269,16 @@ int main (int argc,
     fprintf(stdout, "Usage: %s <ip-address> <gss-name> <hostname> <database-name>\n", argv[0]);
     exit(1);
   }
+
+  /* set logging levels */
+  tr_log_threshold(LOG_CRIT);
+  tr_console_threshold(LOG_DEBUG);
+
   ipaddr = (char *)argv[1];
   gssname = tr_new_name((char *) argv[2]);
   hostname = argv[3];
   if (SQLITE_OK != sqlite3_open(argv[4], &db)) {
-    fprintf(stdout, "Error opening database %s\n", argv[4]);
+    tr_crit("Error opening database %s", argv[4]);
     exit(1);
   }
   sqlite3_busy_timeout( db, 1000);
@@ -284,7 +289,7 @@ int main (int argc,
 
   /* Create a TID server instance */
   if (NULL == (tids = tids_create())) {
-    fprintf(stdout, "Unable to create TIDS instance, exiting.\n");
+    tr_crit("Unable to create TIDS instance, exiting.");
     return 1;
   }
 
@@ -293,7 +298,7 @@ int main (int argc,
   /* Start-up the server, won't return unless there is an error. */
   rc = tids_start(tids, &tids_req_handler , auth_handler, hostname, TID_PORT, gssname);
   
-  fprintf(stdout, "Error in tids_start(), rc = %d. Exiting.\n", rc);
+  tr_crit("Error in tids_start(), rc = %d. Exiting.", rc);
 
   /* Clean-up the TID server instance */
   tids_destroy(tids);

--- a/tid/example/tids_main.c
+++ b/tid/example/tids_main.c
@@ -270,6 +270,9 @@ int main (int argc,
     exit(1);
   }
 
+  /* Use standalone logging */
+  tr_log_open();
+
   /* set logging levels */
   tr_log_threshold(LOG_CRIT);
   tr_console_threshold(LOG_DEBUG);

--- a/tid/tid_req.c
+++ b/tid/tid_req.c
@@ -38,6 +38,8 @@
 #include <talloc.h>
 
 #include <tid_internal.h>
+#include <tr_debug.h>
+
 #include <jansson.h>
 
 static int destroy_tid_req(TID_REQ *req)
@@ -174,7 +176,7 @@ TID_REQ *tid_dup_req (TID_REQ *orig_req)
   TID_REQ *new_req = NULL;
 
   if (NULL == (new_req = malloc(sizeof(TID_REQ)))) {
-    fprintf(stderr, "tid_dup_req: Can't allocated duplicate request.\n");
+    tr_crit("tid_dup_req: Can't allocated duplicate request.");
     return NULL;
   }
 
@@ -185,12 +187,12 @@ TID_REQ *tid_dup_req (TID_REQ *orig_req)
   if ((NULL == (new_req->rp_realm = tr_dup_name(orig_req->rp_realm))) ||
       (NULL == (new_req->realm = tr_dup_name(orig_req->realm))) ||
       (NULL == (new_req->comm = tr_dup_name(orig_req->comm)))) {
-	fprintf(stderr, "tid_dup_req: Can't duplicate request (names).\n");
+	tr_crit("tid_dup_req: Can't duplicate request (names).");
   }
 
   if (orig_req->orig_coi) {
     if (NULL == (new_req->orig_coi = tr_dup_name(orig_req->orig_coi))) {
-      fprintf(stderr, "tid_dup_req: Can't duplicate request (orig_coi).\n");
+      tr_crit("tid_dup_req: Can't duplicate request (orig_coi).");
     }
   }
   

--- a/tid/tids.c
+++ b/tid/tids.c
@@ -53,7 +53,7 @@ static TID_RESP *tids_create_response (TIDS_INSTANCE *tids, TID_REQ *req)
   TID_RESP *resp;
 
   if ((NULL == (resp = talloc_zero(req, TID_RESP)))) {
-    fprintf(stderr, "tids_create_response: Error allocating response structure.\n");
+    tr_crit("tids_create_response: Error allocating response structure.");
     return NULL;
   }
   
@@ -61,12 +61,12 @@ static TID_RESP *tids_create_response (TIDS_INSTANCE *tids, TID_REQ *req)
   if ((NULL == (resp->rp_realm = tr_dup_name(req->rp_realm))) ||
       (NULL == (resp->realm = tr_dup_name(req->realm))) ||
       (NULL == (resp->comm = tr_dup_name(req->comm)))) {
-    fprintf(stderr, "tids_create_response: Error allocating fields in response.\n");
+    tr_crit("tids_create_response: Error allocating fields in response.");
     return NULL;
   }
   if (req->orig_coi) {
     if (NULL == (resp->orig_coi = tr_dup_name(req->orig_coi))) {
-      fprintf(stderr, "tids_create_response: Error allocating fields in response.\n");
+      tr_crit("tids_create_response: Error allocating fields in response.");
       return NULL;
     }
   }
@@ -102,24 +102,24 @@ static int tids_listen (TIDS_INSTANCE *tids, int port)
     } addr;
 
     struct sockaddr_in *saddr = (struct sockaddr_in *) &addr.in4;
-    
+
     saddr->sin_port = htons (port);
     saddr->sin_family = AF_INET;
     saddr->sin_addr.s_addr = INADDR_ANY;
 
     if (0 > (conn = socket (AF_INET, SOCK_STREAM, 0)))
       return conn;
-        
+
     setsockopt(conn, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
 
     if (0 > (rc = bind (conn, (struct sockaddr *) saddr, sizeof(struct sockaddr_in))))
       return rc;
-        
+
     if (0 > (rc = listen(conn, 512)))
       return rc;
-    
-    fprintf (stdout, "tids_listen: TID Server listening on port %d\n", port);
-    return conn; 
+
+    tr_debug("tids_listen: TID Server listening on port %d", port);
+    return conn;
 }
 
 static int tids_auth_cb(gss_name_t clientName, gss_buffer_t displayName,
@@ -145,20 +145,20 @@ static int tids_auth_connection (struct tids_instance *inst,
   nameBuffer.value = name;
   
   if (rc = gsscon_passive_authenticate(conn, nameBuffer, gssctx, tids_auth_cb, inst)) {
-    fprintf(stderr, "tids_auth_connection: Error from gsscon_passive_authenticate(), rc = %d.\n", rc);
+    tr_debug("tids_auth_connection: Error from gsscon_passive_authenticate(), rc = %d.", rc);
     return -1;
   }
 
   if (rc = gsscon_authorize(*gssctx, &auth, &autherr)) {
-    fprintf(stderr, "tids_auth_connection: Error from gsscon_authorize, rc = %d, autherr = %d.\n", 
+    tr_debug("tids_auth_connection: Error from gsscon_authorize, rc = %d, autherr = %d.", 
 	    rc, autherr);
     return -1;
   }
 
   if (auth)
-    fprintf(stdout, "tids_auth_connection: Connection authenticated, conn = %d.\n", conn);
+    tr_debug("tids_auth_connection: Connection authenticated, conn = %d.", conn);
   else
-    fprintf(stderr, "tids_auth_connection: Authentication failed, conn %d.\n", conn);
+    tr_debug("tids_auth_connection: Authentication failed, conn %d.", conn);
 
   return !auth;
 }
@@ -175,18 +175,18 @@ static int tids_read_request (TIDS_INSTANCE *tids, int conn, gss_ctx_id_t *gssct
     return -1;
   }
 
-  fprintf(stdout, "tids_read_request():Request Received, %u bytes.\n", (unsigned) buflen);
+  tr_debug("tids_read_request():Request Received, %u bytes.", (unsigned) buflen);
 
   /* Parse request */
   if (NULL == ((*mreq) = tr_msg_decode(buf, buflen))) {
-    fprintf(stderr, "tids_read_request():Error decoding request.\n");
+    tr_debug("tids_read_request():Error decoding request.");
     free (buf);
     return -1;
   }
 
   /* If this isn't a TID Request, just drop it. */
   if (TID_REQUEST != (*mreq)->msg_type) {
-    fprintf(stderr, "tids_read_request(): Not a TID Request, dropped.\n");
+    tr_debug("tids_read_request(): Not a TID Request, dropped.");
     return -1;
   }
 
@@ -203,7 +203,7 @@ static int tids_handle_request (TIDS_INSTANCE *tids, TR_MSG *mreq, TID_RESP *res
       (!tr_msg_get_req(mreq)->rp_realm) ||
       (!tr_msg_get_req(mreq)->realm) ||
       (!tr_msg_get_req(mreq)->comm)) {
-    fprintf(stderr, "tids_handle_request():Not a valid TID Request.\n");
+    tr_notice("tids_handle_request(): Not a valid TID Request.");
     resp->result = TID_ERROR;
     resp->err_msg = tr_new_name("Bad request format");
     return -1;
@@ -235,7 +235,7 @@ int tids_send_err_response (TIDS_INSTANCE *tids, TID_REQ *req, const char *err_m
     return 0;
 
   if (NULL == (resp = tids_create_response(tids, req))) {
-    fprintf(stderr, "tids_send_err_response: Can't create response.\n");
+    tr_crit("tids_send_err_response: Can't create response.");
     return -1;
   }
 
@@ -256,7 +256,7 @@ int tids_send_response (TIDS_INSTANCE *tids, TID_REQ *req, TID_RESP *resp)
   char *resp_buf;
 
   if ((!tids) || (!req) || (!resp))
-    fprintf (stderr, "tids_send_response: Invalid parameters.\n");
+    tr_debug("tids_send_response: Invalid parameters.");
 
   /* Never send a second response if we already sent one. */
   if (req->resp_sent)
@@ -264,16 +264,17 @@ int tids_send_response (TIDS_INSTANCE *tids, TID_REQ *req, TID_RESP *resp)
 
   mresp.msg_type = TID_RESPONSE;
   tr_msg_set_resp(&mresp, resp);
-  
+
   if (NULL == (resp_buf = tr_msg_encode(&mresp))) {
+
     fprintf(stderr, "tids_send_response: Error encoding json response.\n");
     tr_audit_req(req);
 
     return -1;
   }
 
-  fprintf(stderr, "tids_send_response: Encoded response:\n%s\n", resp_buf);
-  
+  tr_debug("tids_send_response: Encoded response: %s", resp_buf);
+
   /* If external logging is enabled, fire off a message */
   /* TODO Can be moved to end once segfault in gsscon_write_encrypted_token fixed */
   tr_audit_resp(resp);
@@ -281,7 +282,7 @@ int tids_send_response (TIDS_INSTANCE *tids, TID_REQ *req, TID_RESP *resp)
   /* Send the response over the connection */
   if (err = gsscon_write_encrypted_token (req->conn, req->gssctx, resp_buf, 
 					  strlen(resp_buf) + 1)) {
-    fprintf(stderr, "tids_send_response: Error sending response over connection.\n");
+    tr_notice("tids_send_response: Error sending response over connection.");
 
     tr_audit_req(req);
 
@@ -304,17 +305,17 @@ static void tids_handle_connection (TIDS_INSTANCE *tids, int conn)
   gss_ctx_id_t gssctx = GSS_C_NO_CONTEXT;
 
   if (tids_auth_connection(tids, conn, &gssctx)) {
-    fprintf(stderr, "tids_handle_connection: Error authorizing TID Server connection.\n");
+    tr_notice("tids_handle_connection: Error authorizing TID Server connection.");
     close(conn);
     return;
   }
 
-  fprintf(stdout, "tids_handle_connection: Connection authorized!\n");
+  tr_debug("tids_handle_connection: Connection authorized!");
 
   while (1) {	/* continue until an error breaks us out */
 
     if (0 > (rc = tids_read_request(tids, conn, &gssctx, &mreq))) {
-      fprintf(stderr, "tids_handle_connection: Error from tids_read_request(), rc = %d.\n", rc);
+      tr_debug("tids_handle_connection: Error from tids_read_request(), rc = %d.", rc);
       return;
     } else if (0 == rc) {
       continue;
@@ -326,22 +327,22 @@ static void tids_handle_connection (TIDS_INSTANCE *tids, int conn)
 
     /* Allocate a response structure and populate common fields */
     if (NULL == (resp = tids_create_response (tids, tr_msg_get_req(mreq)))) {
-      fprintf(stderr, "tids_handle_connection: Error creating response structure.\n");
+      tr_crit("tids_handle_connection: Error creating response structure.");
       /* try to send an error */
-      tids_send_err_response(tids, tr_msg_get_req(mreq), "Error creating response.\n");
+      tids_send_err_response(tids, tr_msg_get_req(mreq), "Error creating response.");
       return;
     }
 
     if (0 > (rc = tids_handle_request(tids, mreq, resp))) {
-      fprintf(stderr, "tids_handle_connection: Error from tids_handle_request(), rc = %d.\n", rc);
+      tr_debug("tids_handle_connection: Error from tids_handle_request(), rc = %d.", rc);
       /* Fall through, to send the response, either way */
     }
 
     if (0 > (rc = tids_send_response(tids, tr_msg_get_req(mreq), resp))) {
-      fprintf(stderr, "tids_handle_connection: Error from tids_send_response(), rc = %d.\n", rc);
+      tr_debug("tids_handle_connection: Error from tids_send_response(), rc = %d.", rc);
       /* if we didn't already send a response, try to send a generic error. */
       if (!tr_msg_get_req(mreq)->resp_sent)
-	tids_send_err_response(tids, tr_msg_get_req(mreq), "Error sending response.\n");
+	tids_send_err_response(tids, tr_msg_get_req(mreq), "Error sending response.");
       /* Fall through to free the response, either way. */
     }
     
@@ -410,11 +411,9 @@ int tids_start (TIDS_INSTANCE *tids,
 
 void tids_destroy (TIDS_INSTANCE *tids)
 {
-  /* close syslog connection if syslog is enabled */
+  /* clean up logfiles */
   tr_log_close();
 
   if (tids)
     free(tids);
 }
-
-

--- a/tr/tr_main.c
+++ b/tr/tr_main.c
@@ -252,6 +252,9 @@ int main (int argc, const char *argv[])
 
   /* parse command-line arguments? -- TBD */
 
+  /* Use standalone logging */
+  tr_log_open();
+
   /* create a Trust Router instance */
   if (NULL == (tr = tr_create())) {
     tr_crit("Unable to create Trust Router instance, exiting.");

--- a/trust_router.spec
+++ b/trust_router.spec
@@ -1,7 +1,7 @@
 %global optflags %{optflags} -Wno-parentheses
 Name:           trust_router
-Version:        1.4.1
-Release:        3%{?dist}
+Version:        1.4.2
+Release:        1%{?dist}
 Summary:        Moonshot Trust Router
 
 Group:          System Environment/Libraries


### PR DESCRIPTION
Continuation of https://github.com/janetuk/trust_router/pull/4, taking into account feedback from Sam.

Important notes:
 * gsscon is unaffected by this change - there's a handful of printf's left in there as it is messy to correctly import the files needed as it is compiled as a separate library.
 * Severities defined in the log file are lower case analogues of syslog severity levels, as strcmp()'ing macro names is messy.