### PR TITLE
Mark string arguments to tidc_open_connection and tidc_send_request as const

### DIFF
--- a/common/tr_name.c
+++ b/common/tr_name.c
@@ -47,7 +47,7 @@ void tr_free_name (TR_NAME *name)
   free(name);
 }
 
-TR_NAME *tr_new_name (char *name) 
+TR_NAME *tr_new_name (const char *name)
 {
   TR_NAME *new;
 

--- a/common/tr_name.c
+++ b/common/tr_name.c
@@ -43,7 +43,7 @@ void tr_free_name (TR_NAME *name)
     free (name->buf);
     name->buf = NULL;
   }
-  
+
   free(name);
 }
 
@@ -51,7 +51,7 @@ TR_NAME *tr_new_name (char *name)
 {
   TR_NAME *new;
 
-  if (new = malloc(sizeof(TR_NAME))) { 
+  if (new = malloc(sizeof(TR_NAME))) {
     new->len = strlen(name);
     if (new->buf = malloc((new->len)+1)) {
       strcpy(new->buf, name);
@@ -60,7 +60,7 @@ TR_NAME *tr_new_name (char *name)
   return new;
 }
 
-TR_NAME *tr_dup_name (TR_NAME *from) 
+TR_NAME *tr_dup_name (TR_NAME *from)
 {
   TR_NAME *to;
 
@@ -82,7 +82,7 @@ int tr_name_cmp(TR_NAME *one, TR_NAME *two)
 {
   if (one->len != two->len)
     return 1;
-  else 
+  else
     /* TBD -- should really do a length-based comparison */
     return strcmp(one->buf, two->buf);
 }
@@ -98,7 +98,7 @@ void tr_name_strlcat(char *dest, const TR_NAME *src, size_t len)
   else dest[0] = '\0';
 }
 
-  
+
 char * tr_name_strdup(TR_NAME *src)
 {
   char *s = calloc(src->len+1, 1);
@@ -109,4 +109,4 @@ char * tr_name_strdup(TR_NAME *src)
   return s;
 }
 
-  
+

--- a/include/trust_router/tid.h
+++ b/include/trust_router/tid.h
@@ -136,8 +136,8 @@ TR_EXPORT const TID_PATH *tid_srvr_get_path(const TID_SRVR_BLK *);
 
 /* TID Client functions, in tid/tidc.c */
 TR_EXPORT TIDC_INSTANCE *tidc_create (void);
-TR_EXPORT int tidc_open_connection (TIDC_INSTANCE *tidc, char *server, unsigned int port, gss_ctx_id_t *gssctx);
-TR_EXPORT int tidc_send_request (TIDC_INSTANCE *tidc, int conn, gss_ctx_id_t gssctx, char *rp_realm, char *realm, char *coi, TIDC_RESP_FUNC *resp_handler, void *cookie);
+TR_EXPORT int tidc_open_connection (TIDC_INSTANCE *tidc, const char *server, unsigned int port, gss_ctx_id_t *gssctx);
+TR_EXPORT int tidc_send_request (TIDC_INSTANCE *tidc, int conn, gss_ctx_id_t gssctx, const char *rp_realm, const char *realm, const char *coi, TIDC_RESP_FUNC *resp_handler, void *cookie);
 TR_EXPORT int tidc_fwd_request (TIDC_INSTANCE *tidc, TID_REQ *req, TIDC_RESP_FUNC *resp_handler, void *cookie);
 TR_EXPORT DH *tidc_get_dh(TIDC_INSTANCE *);
 TR_EXPORT DH *tidc_set_dh(TIDC_INSTANCE *, DH *);

--- a/include/trust_router/tid.h
+++ b/include/trust_router/tid.h
@@ -146,7 +146,7 @@ TR_EXPORT void tidc_destroy (TIDC_INSTANCE *tidc);
 /* TID Server functions, in tid/tids.c */
 TR_EXPORT TIDS_INSTANCE *tids_create (void);
 TR_EXPORT int tids_start (TIDS_INSTANCE *tids, TIDS_REQ_FUNC *req_handler,
-			  tids_auth_func *auth_handler, const char *hostname, 
+			  tids_auth_func *auth_handler, const char *hostname,
 			  unsigned int port, void *cookie);
 TR_EXPORT int tids_send_response (TIDS_INSTANCE *tids, TID_REQ *req, TID_RESP *resp);
 TR_EXPORT int tids_send_err_response (TIDS_INSTANCE *tids, TID_REQ *req, const char *err_msg);

--- a/include/trust_router/tr_name.h
+++ b/include/trust_router/tr_name.h
@@ -44,7 +44,7 @@ typedef struct tr__name {
   int len;
 } TR_NAME;
 
-TR_EXPORT TR_NAME *tr_new_name (char *name);
+TR_EXPORT TR_NAME *tr_new_name (const char *name);
 TR_EXPORT TR_NAME *tr_dup_name (TR_NAME *from);
 TR_EXPORT void tr_free_name (TR_NAME *name);
 TR_EXPORT int tr_name_cmp (TR_NAME *one, TR_NAME *two);

--- a/tid/tidc.c
+++ b/tid/tidc.c
@@ -60,8 +60,8 @@ void tidc_destroy (TIDC_INSTANCE *tidc)
   talloc_free(tidc);
 }
 
-int tidc_open_connection (TIDC_INSTANCE *tidc, 
-			  char *server,
+int tidc_open_connection (TIDC_INSTANCE *tidc,
+			  const char *server,
 			  unsigned int port,
 			  gss_ctx_id_t *gssctx)
 {
@@ -85,9 +85,9 @@ int tidc_open_connection (TIDC_INSTANCE *tidc,
 int tidc_send_request (TIDC_INSTANCE *tidc,
 		       int conn,
 		       gss_ctx_id_t gssctx,
-		       char *rp_realm,
-		       char *realm, 
-		       char *comm,
+		       const char *rp_realm,
+		       const char *realm,
+		       const char *comm,
 		       TIDC_RESP_FUNC *resp_handler,
 		       void *cookie)
 {

--- a/tid/tidc.c
+++ b/tid/tidc.c
@@ -49,7 +49,7 @@ TIDC_INSTANCE *tidc_create ()
 {
   TIDC_INSTANCE *tidc = NULL;
 
-  if (NULL == (tidc = talloc_zero(NULL, TIDC_INSTANCE))) 
+  if (NULL == (tidc = talloc_zero(NULL, TIDC_INSTANCE)))
     return NULL;
 
   return tidc;
@@ -71,7 +71,7 @@ int tidc_open_connection (TIDC_INSTANCE *tidc,
 
   if (0 == port)
     use_port = TID_PORT;
-  else 
+  else
     use_port = port;
 
   err = gsscon_connect(server, use_port, "trustidentity", &conn, gssctx);
@@ -82,8 +82,8 @@ int tidc_open_connection (TIDC_INSTANCE *tidc,
     return -1;
 }
 
-int tidc_send_request (TIDC_INSTANCE *tidc, 
-		       int conn, 
+int tidc_send_request (TIDC_INSTANCE *tidc,
+		       int conn,
 		       gss_ctx_id_t gssctx,
 		       char *rp_realm,
 		       char *realm, 
@@ -119,8 +119,8 @@ int tidc_send_request (TIDC_INSTANCE *tidc,
   return rc;
 }
 
-int tidc_fwd_request (TIDC_INSTANCE *tidc, 
-		      TID_REQ *tid_req, 
+int tidc_fwd_request (TIDC_INSTANCE *tidc,
+		      TID_REQ *tid_req,
 		      TIDC_RESP_FUNC *resp_handler,
 		      void *cookie)
 {
@@ -142,7 +142,7 @@ int tidc_fwd_request (TIDC_INSTANCE *tidc,
   /* store the response function and cookie */
   // tid_req->resp_func = resp_handler;
   // tid_req->cookie = cookie;
-  
+
 
   /* Encode the request into a json string */
   if (!(req_buf = tr_msg_encode(msg))) {
@@ -154,7 +154,7 @@ int tidc_fwd_request (TIDC_INSTANCE *tidc,
   tr_debug( "%s\n", req_buf);
 
   /* Send the request over the connection */
-  if (err = gsscon_write_encrypted_token (tid_req->conn, tid_req->gssctx, req_buf, 
+  if (err = gsscon_write_encrypted_token (tid_req->conn, tid_req->gssctx, req_buf,
 					  strlen(req_buf))) {
     tr_err( "tidc_fwd_request: Error sending request over connection.\n");
     goto error;
@@ -183,7 +183,7 @@ int tidc_fwd_request (TIDC_INSTANCE *tidc,
     tr_err( "tidc_fwd_request: Error, no response in the response!\n");
     goto error;
   }
-  
+
   if (resp_handler)
     /* Call the caller's response function */
     (*resp_handler)(tidc, tid_req, tr_msg_get_resp(resp_msg), cookie);


### PR DESCRIPTION
These functions are called from the trustrouter integration code in the `rlm_realm` module of FreeRADIUS. The buffers passed as arguments to `tidc_open_connection` and `tidc_send_request` are correctly marked as `const`, but the string arguments of those functions are not marked as `const`.

We cannot add the trustrouter code to the build phase of CIT until this is corrected.
